### PR TITLE
Decrease Ubuntu-based image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,21 @@
 FROM ubuntu:16.04
 
 # System packages
-RUN apt-get update && apt-get install -y curl bzip2
+RUN apt-get update && apt-get install -y curl bzip2 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install miniconda to /miniconda
-RUN curl -LO https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-RUN bash Miniconda3-latest-Linux-x86_64.sh -p /miniconda -b
-RUN rm Miniconda3-latest-Linux-x86_64.sh
+RUN curl -LO https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -p /miniconda -b && \
+    rm Miniconda3-latest-Linux-x86_64.sh
 ENV PATH=/miniconda/bin:${PATH}
-RUN conda update -y conda
 
 # Python packages from conda
-RUN conda update conda && \
+RUN conda update -y conda && \
     conda update pip && \
     conda install -y python=3.6 numpy scipy git psutil && \
     pip install scikit-image Pillow && \
-    pip install git+https://github.com/oeway/ImJoy-Engine#egg=imjoy
+    pip install git+https://github.com/oeway/ImJoy-Engine#egg=imjoy && \
+    conda clean -y --tarballs
+
+ENTRYPOINT ["python", "-m", "imjoy", "--serve", "--host=0.0.0.0"]


### PR DESCRIPTION
This PR refactors the Dockerfile to reduce the size of the built Docker image. The major changes are to clean up `apt` and `conda` caches after installation. I also condense some of the run steps to reduce the number of file system layers and add an `entrypoint`.

### Image size
- Before: 2.43 GB
- After: 1.92 GB