### PR TITLE
Add tox and pytest framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,5 @@ Please submit your issue to [ImJoy/issues ](https://github.com/oeway/ImJoy/issue
   # Install all development requirements and package in development mode.
   pip3 install -r requirements_dev.txt
 ```
+
+- Run `tox` to run all tests and lint, including checking that `black` doesn't change any files.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+aiohttp==3.5.4
+aiohttp_cors==0.7.0
+janus==0.4.0
+numpy==1.16.3
+psutil==5.6.2
+python-socketio==4.0.1
+pyyaml==5.1
+requests==2.21.0
+six==1.12.0
+websocket-client==0.56.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,5 @@
+-r requirements.txt
 -r requirements_lint.txt
+-r requirements_test.txt
+tox
 -e .

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,3 @@
+pytest==4.4.1
+pytest-cov==2.7.1
+pytest-timeout==1.3.3

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test the ImJoy engine."""

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -1,0 +1,13 @@
+"""Test the testing framework."""
+import pytest
+
+
+def test_framework_pass():
+    """Test that the testing framework works and a test can pass."""
+    assert True
+
+
+@pytest.mark.xfail
+def test_framework_fail():
+    """Test that the testing framework works and a test can fail."""
+    assert False

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,22 @@
+[tox]
+envlist = py36, lint
+skip_missing_interpreters = True
+
+[travis]
+python =
+  3.6: py36, lint
+
+[testenv]
+commands =
+  pytest -v --timeout=30 --cov=imjoy --cov-report= {posargs}
+deps =
+  -rrequirements.txt
+  -rrequirements_test.txt
+
+[testenv:lint]
+basepython = python3
+ignore_errors = True
+commands =
+  black --check ./
+deps =
+  -rrequirements_lint.txt


### PR DESCRIPTION
Run `tox` to run all tests and lint, including checking that `black` doesn't change any files.

**Changes**
* Add tox as a dev requirement.
* Add tox.ini file with tox config. Run all tests in Python 3.
* Add test requirements with pytest and coverage and timeout plugins.
* Add production requirements in requirements.txt file.
* Add some dummy tests to exercise pytest.