### PR TITLE
Improve allow detach

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# ImJoy Plugin Engine [![Build Status](https://travis-ci.com/oeway/ImJoy-Engine.svg?branch=master)](https://travis-ci.com/oeway/ImJoy-Engine)
+[![Build Status](https://travis-ci.com/oeway/ImJoy-Engine.svg?branch=master)](https://travis-ci.com/oeway/ImJoy-Engine) ![PyPI](https://img.shields.io/pypi/v/imjoy.svg?style=popout) ![GitHub](https://img.shields.io/github/license/oeway/ImJoy-Engine.svg)
+# ImJoy Plugin Engine
 The plugin engine used for running python plugins in ImJoy (https://imjoy.io).
 
 ## Installation (Desktop App)

--- a/imjoy/imjoyPluginEngine.py
+++ b/imjoy/imjoyPluginEngine.py
@@ -743,7 +743,7 @@ async def on_init_plugin(sid, kwargs):
             plugin_info = resumePluginSession(pid, session_id, plugin_signature)
             if plugin_info is not None:
                 if "aborting" in plugin_info:
-                    logger.info("Waiting for plugin %s to abort", plugin_info['id'])
+                    logger.info("Waiting for plugin %s to abort", plugin_info["id"])
                     await plugin_info["aborting"]
                 else:
                     logger.debug("plugin already initialized: %s", pid)
@@ -758,7 +758,11 @@ async def on_init_plugin(sid, kwargs):
                         "work_dir": os.path.abspath(work_dir),
                     }
             else:
-                logger.info("failed to resume single instance plugin: %s, %s", pid, plugin_signature)
+                logger.info(
+                    "failed to resume single instance plugin: %s, %s",
+                    pid,
+                    plugin_signature,
+                )
 
         secretKey = str(uuid.uuid4())
         abort = threading.Event()

--- a/imjoy/imjoyPluginEngine.py
+++ b/imjoy/imjoyPluginEngine.py
@@ -181,15 +181,17 @@ def killProcess(pid):
                 if proc.is_running():
                     proc.kill()
             except psutil.NoSuchProcess:
-                logger.info('subprocess %s has already been killed', pid)
+                logger.info("subprocess %s has already been killed", pid)
             except Exception as e:
                 logger.error(
-                    "WARNING: failed to kill a subprocess (PID={}). Error: {}".format(pid, str(e))
+                    "WARNING: failed to kill a subprocess (PID={}). Error: {}".format(
+                        pid, str(e)
+                    )
                 )
         cp.kill()
         logger.info("plugin process %s was killed.", pid)
     except psutil.NoSuchProcess:
-        logger.info('process %s has already been killed', pid)
+        logger.info("process %s has already been killed", pid)
     except Exception as e:
         logger.error(
             "WARNING: failed to kill a process (PID={}), "
@@ -460,13 +462,13 @@ def addPlugin(plugin_info, sid=None):
 
 
 def disconnectPlugin(sid):
-    logger.info('disconnecting plugin session %s', sid)
+    logger.info("disconnecting plugin session %s", sid)
     if sid in plugin_sids:
         pid = plugin_sids[sid]["id"]
         if pid in plugins:
-            logger.info('clean up plugin %s', pid)
+            logger.info("clean up plugin %s", pid)
             if plugins[pid]["signature"] in plugin_signatures:
-                logger.info('clean up plugin signature %s', plugins[pid]["signature"])
+                logger.info("clean up plugin signature %s", plugins[pid]["signature"])
                 del plugin_signatures[plugins[pid]["signature"]]
             del plugins[pid]
         del plugin_sids[sid]
@@ -476,7 +478,7 @@ def disconnectPlugin(sid):
                 if p["id"] == pid:
                     exist = p
             if exist:
-                logger.info('clean up plugin session %s', session_id)
+                logger.info("clean up plugin session %s", session_id)
                 plugin_sessions[session_id].remove(exist)
                 killPlugin(exist["id"])
 
@@ -498,13 +500,14 @@ def killPlugin(pid):
         if "sid" in plugins[pid]:
             if plugins[pid]["sid"] in plugin_sids:
                 del plugin_sids[plugins[pid]["sid"]]
-        
+
         if plugins[pid]["signature"] in plugin_signatures:
-            logger.info('clean up killed plugin signature %s', plugins[pid]["signature"])
+            logger.info(
+                "clean up killed plugin signature %s", plugins[pid]["signature"]
+            )
             del plugin_signatures[plugins[pid]["signature"]]
-        logger.info('clean up killed plugin %s', pid)
+        logger.info("clean up killed plugin %s", pid)
         del plugins[pid]
-        
 
 
 async def killAllPlugins(ssid):
@@ -744,7 +747,7 @@ async def on_init_plugin(sid, kwargs):
             secret = resumePluginSession(pid, session_id, plugin_signature)
             if secret is not None:
                 if "aborting" in plugins[pid]:
-                    logger.info('Waiting for plugin %s to abort', pid)
+                    logger.info("Waiting for plugin %s to abort", pid)
                     await plugins[pid]["aborting"]
                 else:
                     logger.debug("plugin already initialized: %s", pid)
@@ -1564,7 +1567,11 @@ def launch_plugin(
                 cwd=work_dir,
                 stderr=subprocess.PIPE,
             )
-            logging_callback("Running requirements subprocess(pid={}): {}".format(process.pid, requirements_cmd))
+            logging_callback(
+                "Running requirements subprocess(pid={}): {}".format(
+                    process.pid, requirements_cmd
+                )
+            )
             setPluginPID(pid, process.pid)
             ret = process.wait()
             _, errors = process.communicate()
@@ -1650,7 +1657,7 @@ def launch_plugin(
 
     args = " ".join(args)
     logger.info("Task subprocess args: %s", args)
-    
+
     # set system/version dependent "start_new_session" analogs
     # https://docs.python.org/2/library/subprocess.html#converting-argument-sequence
     kwargs = {}

--- a/imjoy/imjoyPluginEngine.py
+++ b/imjoy/imjoyPluginEngine.py
@@ -747,9 +747,6 @@ async def on_init_plugin(sid, kwargs):
                     await plugin_info["aborting"]
                 else:
                     logger.debug("plugin already initialized: %s", pid)
-                    # await sio.emit(
-                    #     'message_from_plugin_'+secret,
-                    #     {"type": "initialized", "dedicatedThread": True})
                     return {
                         "success": True,
                         "resumed": True,

--- a/imjoy/imjoyPluginEngine.py
+++ b/imjoy/imjoyPluginEngine.py
@@ -45,7 +45,8 @@ try:
     import pkg_resources  # part of setuptools
 
     engine_version = pkg_resources.require("imjoy")[0].version
-except:
+except Exception as e:
+    print("Engine version cannot be determined:" + str(e))
     engine_version = None
 
 try:

--- a/imjoy/imjoyPluginEngine.py
+++ b/imjoy/imjoyPluginEngine.py
@@ -42,6 +42,13 @@ if sys.platform == "win32":
 
 
 try:
+    import pkg_resources  # part of setuptools
+
+    engine_version = pkg_resources.require("imjoy")[0].version
+except:
+    engine_version = None
+
+try:
     import psutil
 except Exception as e:
     print(
@@ -737,9 +744,16 @@ async def on_init_plugin(sid, kwargs):
             workspace,
         )
 
-        plugin_signature = "{}/{}/{}/{}".format(client_id, workspace, pname, tag)
-
         if "single-instance" in flags:
+            plugin_signature = "{}/{}".format(pname, tag)
+            resume = True
+        elif "allow-detach" in flags:
+            plugin_signature = "{}/{}/{}/{}".format(client_id, workspace, pname, tag)
+            resume = True
+        else:
+            resume = False
+
+        if resume:
             plugin_info = resumePluginSession(pid, session_id, plugin_signature)
             if plugin_info is not None:
                 if "aborting" in plugin_info:
@@ -1004,6 +1018,8 @@ async def on_register_client(sid, kwargs):
         logger.info("register client: %s", kwargs)
 
         engine_info = {"api_version": API_VERSION}
+        if engine_version is not None:
+            engine_info["version"] = engine_version
         engine_info["platform"] = {
             "uname": ", ".join(platform.uname()),
             "machine": platform.machine(),
@@ -1728,14 +1744,11 @@ def launch_plugin(
 
 
 async def on_startup(app):
-    try:
-        import pkg_resources  # part of setuptools
-
-        version = pkg_resources.require("imjoy")[0].version
-        print("ImJoy Python Plugin Engine (version {})".format(version))
-    except:
+    if engine_version:
+        print("ImJoy Python Plugin Engine (version {})".format(engine_version))
+    else:
         print("ImJoy Plugin Engine is ready.")
-        pass
+
     if opt.serve:
         print(
             "You can access your local ImJoy web app through "

--- a/imjoy/imjoyPluginEngine.py
+++ b/imjoy/imjoyPluginEngine.py
@@ -752,6 +752,7 @@ async def on_init_plugin(sid, kwargs):
             plugin_signature = "{}/{}/{}/{}".format(client_id, workspace, pname, tag)
             resume = True
         else:
+            plugin_signature = None
             resume = False
 
         if resume:

--- a/imjoy/imjoyPluginEngine.py
+++ b/imjoy/imjoyPluginEngine.py
@@ -721,9 +721,9 @@ async def on_init_plugin(sid, kwargs):
             return {"success": False}
         pid = kwargs["id"]
         config = kwargs.get("config", {})
-        env = config.get("env", None)
+        env = config.get("env")
         cmd = config.get("cmd", "python")
-        pname = config.get("name", None)
+        pname = config.get("name")
         flags = config.get("flags", [])
         tag = config.get("tag", "")
         requirements = config.get("requirements", []) or []
@@ -965,7 +965,7 @@ async def on_register_client(sid, kwargs):
     if base_url.endswith("/"):
         base_url = base_url[:-1]
 
-    token = kwargs.get("token", None)
+    token = kwargs.get("token")
     if token != opt.token:
         logger.debug("token mismatch: %s != %s", token, opt.token)
         print("======== Connection Token: " + opt.token + " ========")
@@ -1062,7 +1062,7 @@ async def on_list_dir(sid, kwargs):
             path = os.path.join(workspace_dir, path)
         path = os.path.normpath(os.path.expanduser(path))
 
-        type = kwargs.get("type", None)
+        type = kwargs.get("type")
         recursive = kwargs.get("recursive", False)
         files_list = {"success": True}
         files_list["path"] = path
@@ -1090,7 +1090,7 @@ async def on_remove_files(sid, kwargs):
     if not os.path.isabs(path):
         path = os.path.join(workspace_dir, path)
     path = os.path.normpath(os.path.expanduser(path))
-    type = kwargs.get("type", None)
+    type = kwargs.get("type")
     recursive = kwargs.get("recursive", False)
 
     if os.path.exists(path) and not os.path.isdir(path) and type == "file":
@@ -1250,10 +1250,10 @@ async def download_file(request):
         raise web.HTTPForbidden(text="Invalid URL")
     fileInfo = generatedUrls[urlid]
     if fileInfo.get("password", False):
-        password = request.match_info.get("password", None)
+        password = request.match_info.get("password")
         if password != fileInfo["password"]:
             raise web.HTTPForbidden(text="Incorrect password for accessing this file.")
-    headers = fileInfo.get("headers", None)
+    headers = fileInfo.get("headers")
     default_headers = {}
     if fileInfo["type"] == "dir":
         dirname = os.path.dirname(name)
@@ -1359,7 +1359,7 @@ async def on_get_file_url(sid, kwargs):
         fileInfo["type"] = "dir"
     else:
         fileInfo["type"] = "file"
-    if kwargs.get("headers", None):
+    if kwargs.get("headers"):
         fileInfo["headers"] = kwargs["headers"]
     _, name = os.path.split(path)
     fileInfo["name"] = name
@@ -1369,7 +1369,7 @@ async def on_get_file_url(sid, kwargs):
         urlid = str(uuid.uuid4())
         generatedUrls[urlid] = fileInfo
         base_url = kwargs.get("base_url", registered_sessions[sid]["base_url"])
-        if kwargs.get("password", None):
+        if kwargs.get("password"):
             fileInfo["password"] = kwargs["password"]
             generatedUrlFiles[path] = "{}/file/{}@{}/{}".format(
                 base_url, urlid, fileInfo["password"], name

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="imjoy",
-    version="0.7.60",
+    version="0.7.61",
     description="ImJoy Plugin Engine for running Python plugins locally or remotely from ImJoy.io",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="imjoy",
-    version="0.7.61",
+    version="0.7.62",
     description="ImJoy Plugin Engine for running Python plugins locally or remotely from ImJoy.io",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Currently, the `allow-detach` flag only tells the process to run when detached from ImJoy app, but it doesn't provide a way to reattach. This is a fix to this which allows reattach (same client, same workspace, same plugin name and same tag).