### PR TITLE
upgrade twine wheel and setuptools

### DIFF
--- a/imjoy/VERSION
+++ b/imjoy/VERSION
@@ -1,4 +1,4 @@
 {
-    "version": "0.7.64",
+    "version": "0.7.65",
     "api_version": "0.1.1"
 }

--- a/utils/publish.sh
+++ b/utils/publish.sh
@@ -1,4 +1,8 @@
-pip install twine
+pip install -U twine
+pip install -U wheel
+pip install -U setuptools
+rm -rf ./build
 rm ./dist/*
 python setup.py sdist bdist_wheel
 twine upload dist/*
+rm -rf ./build


### PR DESCRIPTION
* upgrade  twine wheel and setuptools
 * Fixes readme rendering on pypi ( https://pypi.org/project/imjoy/ )

The readme file failed to render as the right format due to an outdated wheel version, reference here: https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi/

Closes https://github.com/oeway/ImJoy/issues/117