### PR TITLE
Refactor worker job handling

### DIFF
--- a/imjoy/VERSION
+++ b/imjoy/VERSION
@@ -1,4 +1,4 @@
 {
-    "version": "0.7.67",
+    "version": "0.7.68",
     "api_version": "0.1.1"
 }

--- a/imjoy/imjoyPluginEngine.py
+++ b/imjoy/imjoyPluginEngine.py
@@ -847,7 +847,6 @@ async def on_init_plugin(sid, kwargs):
             if "aborting" in plugin_info:
                 plugin_info["aborting"].set_result(success)
             message = str(message or "")
-            message = message[:100] + (message[100:] and "..")
             logger.info(
                 "disconnecting from plugin (success:%s, message: %s)",
                 str(success),

--- a/imjoy/imjoyUtils.py
+++ b/imjoy/imjoyUtils.py
@@ -1,16 +1,8 @@
 """Provide utils for Python 2 plugins."""
 import copy
-import sys
 import threading
 import time
 import uuid
-
-try:
-    import queue
-except ImportError:
-    import Queue as queue
-
-from .worker import JOB_HANDLERS
 
 
 def debounce(s):
@@ -111,26 +103,6 @@ class ReferenceStore:
             _id = getKeyByValue(self._store, obj.__jailed_pairs__)
             self.fetch(_id)
         return obj
-
-
-def task_worker(conn, sync_q, logger, abort):
-    """Implement a task worker."""
-    while True:
-        if abort is not None and abort.is_set():
-            break
-        try:
-            job = sync_q.get()
-        except queue.Empty:
-            time.sleep(0.1)
-            continue
-        sync_q.task_done()
-        if job is None:
-            continue
-        handler = JOB_HANDLERS.get(job["type"])
-        if handler is None:
-            continue
-        handler(conn, job, logger)
-        sys.stdout.flush()
 
 
 class Promise(object):

--- a/imjoy/imjoyUtils3.py
+++ b/imjoy/imjoyUtils3.py
@@ -9,7 +9,6 @@ def make_coro(func):
 
     async def wrapper(*args, **kwargs):
         """Run the normal function."""
-        print("RUNNING WRAPT FUNCTION IN CORO")
         return func(*args, **kwargs)
 
     return wrapper

--- a/imjoy/imjoyUtils3.py
+++ b/imjoy/imjoyUtils3.py
@@ -4,6 +4,17 @@ import asyncio
 from imjoyUtils import Promise
 
 
+def make_coro(func):
+    """Wrap a normal function with a coroutine."""
+
+    async def wrapper(*args, **kwargs):
+        """Run the normal function."""
+        print("RUNNING WRAPT FUNCTION IN CORO")
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
 class FuturePromise(Promise, asyncio.Future):
     """Represent a promise as a future."""
 

--- a/imjoy/imjoyUtils3.py
+++ b/imjoy/imjoyUtils3.py
@@ -1,31 +1,7 @@
 """Provide utils for Python 3 plugins."""
 import asyncio
-import sys
-import traceback
 
 from imjoyUtils import Promise
-
-from .worker3 import JOB_HANDLERS_PY3
-
-
-async def task_worker(conn, async_q, logger, abort=None):
-    """Implement a task worker."""
-    while True:
-        if abort is not None and abort.is_set():
-            break
-        job = await async_q.get()
-        if job is None:
-            continue
-        handler = JOB_HANDLERS_PY3.get(job["type"])
-        if handler is None:
-            continue
-        try:
-            await handler(conn, job, logger)
-        except Exception:
-            print("error occured in the loop.", traceback.format_exc())
-        finally:
-            sys.stdout.flush()
-            async_q.task_done()
 
 
 class FuturePromise(Promise, asyncio.Future):

--- a/imjoy/imjoyUtils3.py
+++ b/imjoy/imjoyUtils3.py
@@ -5,7 +5,7 @@ import traceback
 
 from imjoyUtils import Promise
 
-from .worker import JOB_HANDLERS_PY3
+from .worker3 import JOB_HANDLERS_PY3
 
 
 async def task_worker(conn, async_q, logger, abort=None):

--- a/imjoy/imjoyUtils3.py
+++ b/imjoy/imjoyUtils3.py
@@ -2,124 +2,25 @@
 import asyncio
 import sys
 import traceback
-import inspect
 
-from imjoyUtils import Promise, formatTraceback
+from imjoyUtils import Promise
+
+from .worker import JOB_HANDLERS_PY3
 
 
-async def task_worker(self, async_q, logger, abort=None):
+async def task_worker(conn, async_q, logger, abort=None):
     """Implement a task worker."""
     while True:
         if abort is not None and abort.is_set():
             break
-        d = await async_q.get()
+        job = await async_q.get()
+        if job is None:
+            continue
+        handler = JOB_HANDLERS_PY3.get(job["type"])
+        if handler is None:
+            continue
         try:
-            if d is None:
-                continue
-            if d["type"] == "getInterface":
-                self._sendInterface()
-            elif d["type"] == "setInterface":
-                self._setRemote(d["api"])
-                self.emit({"type": "interfaceSetAsRemote"})
-                if not self._init:
-                    self.emit({"type": "getInterface"})
-                    self._init = True
-            elif d["type"] == "interfaceSetAsRemote":
-                # self.emit({'type':'getInterface'})
-                self._remote_set = True
-            elif d["type"] == "execute":
-                if not self._executed:
-                    try:
-                        t = d["code"]["type"]
-                        if t == "script":
-                            content = d["code"]["content"]
-                            exec(content, self._local)
-                            self._executed = True
-                        elif t == "requirements":
-                            pass
-                        else:
-                            raise Exception("unsupported type")
-                        self.emit({"type": "executeSuccess"})
-                    except Exception as e:
-                        traceback_error = traceback.format_exc()
-                        logger.error("error during execution: %s", traceback_error)
-                        self.emit({"type": "executeFailure", "error": traceback_error})
-
-            elif d["type"] == "method":
-                if d["name"] in self._interface:
-                    if "promise" in d:
-                        try:
-                            resolve, reject = self._unwrap(d["promise"], False)
-                            method = self._interface[d["name"]]
-                            args = self._unwrap(d["args"], True)
-                            # args.append({'id': self.id})
-                            result = method(*args)
-                            if result is not None and inspect.isawaitable(result):
-                                result = await result
-                            resolve(result)
-                        except Exception as e:
-                            traceback_error = traceback.format_exc()
-                            logger.error(
-                                "error in method %s: %s", d["name"], traceback_error
-                            )
-                            reject(Exception(formatTraceback(traceback_error)))
-                    else:
-                        try:
-                            method = self._interface[d["name"]]
-                            args = self._unwrap(d["args"], True)
-                            # args.append({'id': self.id})
-                            result = method(*args)
-                            if result is not None and inspect.isawaitable(result):
-                                await result
-                        except Exception:
-                            logger.error(
-                                "error in method %s: %s",
-                                d["name"],
-                                traceback.format_exc(),
-                            )
-                else:
-                    raise Exception("method " + d["name"] + " is not found.")
-            elif d["type"] == "callback":
-                if "promise" in d:
-                    resolve, reject = self._unwrap(d["promise"], False)
-                    try:
-                        method = self._store.fetch(d["num"])
-                        if method is None:
-                            raise Exception(
-                                "Callback function can only called once, "
-                                "if you want to call a function for multiple times, "
-                                "please make it as a plugin api function. "
-                                "See https://imjoy.io/docs for more details."
-                            )
-                        args = self._unwrap(d["args"], True)
-                        result = method(*args)
-                        if result is not None and inspect.isawaitable(result):
-                            result = await result
-                        resolve(result)
-                    except Exception as e:
-                        traceback_error = traceback.format_exc()
-                        logger.error(
-                            "error in method %s: %s", d["num"], traceback_error
-                        )
-                        reject(Exception(formatTraceback(traceback_error)))
-                else:
-                    try:
-                        method = self._store.fetch(d["num"])
-                        if method is None:
-                            raise Exception(
-                                "Callback function can only called once, "
-                                "if you want to call a function for multiple times, "
-                                "please make it as a plugin api function. "
-                                "See https://imjoy.io/docs for more details."
-                            )
-                        args = self._unwrap(d["args"], True)
-                        result = method(*args)
-                        if result is not None and inspect.isawaitable(result):
-                            await result
-                    except Exception:
-                        logger.error(
-                            "error in method %s: %s", d["num"], traceback.format_exc()
-                        )
+            await handler(conn, job, logger)
         except Exception:
             print("error occured in the loop.", traceback.format_exc())
         finally:
@@ -139,14 +40,14 @@ class FuturePromise(Promise, asyncio.Future):
     def resolve(self, result):
         """Resolve promise."""
         if self._resolve_handler or self._finally_handler:
-            Promise.resolve(self, result)
+            super().resolve(self, result)
         else:
             self.loop.call_soon(self.set_result, result)
 
     def reject(self, error):
         """Reject promise."""
         if self._catch_handler or self._finally_handler:
-            Promise.reject(self, error)
+            super().reject(self, error)
         else:
             if error:
                 self.loop.call_soon(self.set_exception, Exception())

--- a/imjoy/imjoyWorkerTemplate.py
+++ b/imjoy/imjoyWorkerTemplate.py
@@ -15,13 +15,13 @@ from imjoyUtils import ReferenceStore, debounce, dotdict, setInterval
 if sys.version_info >= (3, 0):
     import asyncio
     import janus
-    from imjoyUtils3 import FuturePromise
-    from .worker3 import task_worker
+    from imjoy.imjoyUtils3 import FuturePromise
+    from imjoy.worker3 import task_worker
 
     PYTHON3 = True
 else:
-    from imjoyUtils import Promise
-    from .worker import task_worker
+    from imjoy.imjoyUtils import Promise
+    from imjoy.worker import task_worker
 
     PYTHON3 = False
 

--- a/imjoy/imjoyWorkerTemplate.py
+++ b/imjoy/imjoyWorkerTemplate.py
@@ -15,11 +15,13 @@ from imjoyUtils import ReferenceStore, debounce, dotdict, setInterval
 if sys.version_info >= (3, 0):
     import asyncio
     import janus
-    from imjoyUtils3 import task_worker, FuturePromise
+    from imjoyUtils3 import FuturePromise
+    from .worker3 import task_worker
 
     PYTHON3 = True
 else:
-    from imjoyUtils import task_worker, Promise
+    from imjoyUtils import Promise
+    from .worker import task_worker
 
     PYTHON3 = False
 

--- a/imjoy/imjoyWorkerTemplate.py
+++ b/imjoy/imjoyWorkerTemplate.py
@@ -15,13 +15,13 @@ from imjoyUtils import ReferenceStore, debounce, dotdict, setInterval
 if sys.version_info >= (3, 0):
     import asyncio
     import janus
-    from imjoy.imjoyUtils3 import FuturePromise
-    from imjoy.worker3 import task_worker
+    from imjoyUtils3 import FuturePromise
+    from worker3 import task_worker
 
     PYTHON3 = True
 else:
-    from imjoy.imjoyUtils import Promise
-    from imjoy.worker import task_worker
+    from imjoyUtils import Promise
+    from worker import task_worker
 
     PYTHON3 = False
 

--- a/imjoy/util/__init__.py
+++ b/imjoy/util/__init__.py
@@ -1,0 +1,17 @@
+"""Provide utilities that should not be aware of ImJoy engine."""
+
+
+class Registry(dict):
+    """Registry of items."""
+
+    # https://github.com/home-assistant/home-assistant/blob/
+    # 2a9fd9ae269e8929084e53ab12901e96aec93e7d/homeassistant/util/decorator.py
+    def register(self, name):
+        """Return decorator to register item with a specific name."""
+
+        def decorator(func):
+            """Register decorated function."""
+            self[name] = func
+            return func
+
+        return decorator

--- a/imjoy/util/__init__.py
+++ b/imjoy/util/__init__.py
@@ -1,11 +1,6 @@
 """Provide utilities that should not be aware of ImJoy engine."""
 
 
-async def def_a_coroutine():
-    """Make a comp test."""
-    pass
-
-
 class Registry(dict):
     """Registry of items."""
 
@@ -20,13 +15,3 @@ class Registry(dict):
             return func
 
         return decorator
-
-
-def make_coro(func):
-    """Wrap a normal function with a coroutine."""
-
-    async def wrapper(*args, **kwargs):
-        """Run the normal function."""
-        return func(*args, **kwargs)
-
-    return wrapper

--- a/imjoy/util/__init__.py
+++ b/imjoy/util/__init__.py
@@ -1,6 +1,11 @@
 """Provide utilities that should not be aware of ImJoy engine."""
 
 
+async def def_a_coroutine():
+    """Make a comp test."""
+    pass
+
+
 class Registry(dict):
     """Registry of items."""
 

--- a/imjoy/util/__init__.py
+++ b/imjoy/util/__init__.py
@@ -15,3 +15,13 @@ class Registry(dict):
             return func
 
         return decorator
+
+
+def make_coro(func):
+    """Wrap a normal function with a coroutine."""
+
+    async def wrapper(*args, **kwargs):
+        """Run the normal function."""
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/imjoy/worker.py
+++ b/imjoy/worker.py
@@ -32,7 +32,10 @@ def task_worker(conn, sync_q, logger, abort):
         handler = JOB_HANDLERS.get(job["type"])
         if handler is None:
             continue
-        handler(conn, job, logger)
+        try:
+            handler(conn, job, logger)
+        except Exception:
+            print("error occured in the loop.", traceback.format_exc())
         sys.stdout.flush()
 
 

--- a/imjoy/worker.py
+++ b/imjoy/worker.py
@@ -1,0 +1,221 @@
+"""Provide worker functions."""
+import inspect
+import traceback
+
+from .imjoyUtils import formatTraceback
+from .util import Registry
+
+# pylint: disable=unused-argument
+
+JOB_HANDLERS = Registry()
+
+
+@JOB_HANDLERS.register("getInterface")
+def handle_get_interface(conn, job, logger):
+    """Handle get interface."""
+    conn.send_interface()
+
+
+@JOB_HANDLERS.register("setInterface")
+def handle_set_interface(conn, job, logger):
+    """Handle set interface."""
+    conn.set_remote(job["api"])
+    conn.emit({"type": "interfaceSetAsRemote"})
+    if not conn.init:
+        conn.emit({"type": "getInterface"})
+        conn.init = True
+
+
+@JOB_HANDLERS.register("interfaceSetAsRemote")
+def handle_set_interface_as_remote(conn, job, logger):
+    """Handle set interface as remote."""
+    # conn.emit({'type':'getInterface'})
+    conn.remote_set = True
+
+
+@JOB_HANDLERS.register("execute")
+def handle_execute(conn, job, logger):
+    """Handle execute."""
+    if not conn.executed:
+        try:
+            type_ = job["code"]["type"]
+            if type_ == "script":
+                content = job["code"]["content"]
+                exec(content, conn.local)  # pylint: disable=exec-used
+                conn.executed = True
+            elif type_ == "requirements":
+                pass
+            else:
+                raise Exception("unsupported type")
+            conn.emit({"type": "executeSuccess"})
+        except Exception as exc:  # pylint: disable=broad-except
+            traceback_error = traceback.format_exc()
+            logger.error("error during execution: %s", traceback_error)
+            conn.emit({"type": "executeFailure", "error": traceback_error})
+
+
+@JOB_HANDLERS.register("method")
+def handle_method(conn, job, logger):
+    """Handle method."""
+    interface = conn.interface
+    if "pid" in job and job["pid"] is not None:
+        interface = conn.plugin_interfaces[job["pid"]]
+    if job["name"] in interface:
+        if "promise" in job:
+            try:
+                resolve, reject = conn.unwrap(job["promise"], False)
+                method = interface[job["name"]]
+                args = conn.unwrap(job["args"], True)
+                # args.append({'id': conn.id})
+                result = method(*args)
+                resolve(result)
+            except Exception as exc:  # pylint: disable=broad-except
+                traceback_error = traceback.format_exc()
+                logger.error(
+                    "error in method %s: %s", job["name"], traceback_error
+                )
+                reject(Exception(formatTraceback(traceback_error)))
+        else:
+            try:
+                method = interface[job["name"]]
+                args = conn.unwrap(job["args"], True)
+                # args.append({'id': conn.id})
+                method(*args)
+            except Exception:  # pylint: disable=broad-except
+                logger.error(
+                    "error in method %s: %s", job["name"], traceback.format_exc()
+                )
+    else:
+        raise Exception("method " + job["name"] + " is not found.")
+
+
+@JOB_HANDLERS.register("callback")
+def handle_callback(conn, job, logger):
+    """Handle callback."""
+    if "promise" in job:
+        resolve, reject = conn.unwrap(job["promise"], False)
+        try:
+            method = conn.store.fetch(job["num"])
+            if method is None:
+                raise Exception(
+                    "Callback function can only called once, "
+                    "if you want to call a function for multiple times, "
+                    "please make it as a plugin api function. "
+                    "See https://imjoy.io/docs for more details."
+                )
+            args = conn.unwrap(job["args"], True)
+            result = method(*args)
+            resolve(result)
+        except Exception as exc:  # pylint: disable=broad-except
+            traceback_error = traceback.format_exc()
+            logger.error(
+                "error in method %s: %s", job["num"], traceback_error
+            )
+            reject(Exception(formatTraceback(traceback_error)))
+    else:
+        try:
+            method = conn.store.fetch(job["num"])
+            if method is None:
+                raise Exception(
+                    "Callback function can only called once, "
+                    "if you want to call a function for multiple times, "
+                    "please make it as a plugin api function. "
+                    "See https://imjoy.io/docs for more details."
+                )
+            args = conn.unwrap(job["args"], True)
+            method(*args)
+        except Exception:  # pylint: disable=broad-except
+            logger.error("error in method %s: %s", job["num"], traceback.format_exc())
+
+
+def make_coro(func):
+    """Wrap a normal function with a coroutine."""
+
+    async def wrapper(*args, **kwargs):
+        """Run the normal function."""
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+JOB_HANDLERS_PY3 = Registry()
+JOB_HANDLERS_PY3.update({name: make_coro(func) for name, func in JOB_HANDLERS.items()})
+
+
+@JOB_HANDLERS_PY3.register("method")
+async def handle_method_py3(conn, job, logger):
+    """Handle method."""
+    if job["name"] in conn.interface:
+        if "promise" in job:
+            try:
+                resolve, reject = conn.unwrap(job["promise"], False)
+                method = conn.interface[job["name"]]
+                args = conn.unwrap(job["args"], True)
+                # args.append({'id': conn.id})
+                result = method(*args)
+                if result is not None and inspect.isawaitable(result):
+                    result = await result
+                resolve(result)
+            except Exception as exc:  # pylint: disable=broad-except
+                traceback_error = traceback.format_exc()
+                logger.error(
+                    "error in method %s: %s", job["name"], traceback_error
+                )
+                reject(Exception(formatTraceback(traceback_error)))
+        else:
+            try:
+                method = conn.interface[job["name"]]
+                args = conn.unwrap(job["args"], True)
+                # args.append({'id': conn.id})
+                result = method(*args)
+                if result is not None and inspect.isawaitable(result):
+                    await result
+            except Exception:  # pylint: disable=broad-except
+                logger.error(
+                    "error in method %s: %s", job["name"], traceback.format_exc()
+                )
+    else:
+        raise Exception("method " + job["name"] + " is not found.")
+
+
+@JOB_HANDLERS_PY3.register("callback")
+async def handle_callback_py3(conn, job, logger):
+    """Handle callback."""
+    if "promise" in job:
+        resolve, reject = conn.unwrap(job["promise"], False)
+        try:
+            method = conn.store.fetch(job["num"])
+            if method is None:
+                raise Exception(
+                    "Callback function can only called once, "
+                    "if you want to call a function for multiple times, "
+                    "please make it as a plugin api function. "
+                    "See https://imjoy.io/docs for more details."
+                )
+            args = conn.unwrap(job["args"], True)
+            result = method(*args)
+            if result is not None and inspect.isawaitable(result):
+                result = await result
+            resolve(result)
+        except Exception as exc:  # pylint: disable=broad-except
+            traceback_error = traceback.format_exc()
+            logger.error(
+                "error in method %s: %s", job["num"], traceback_error
+            )
+            reject(Exception(formatTraceback(traceback_error)))
+    else:
+        try:
+            method = conn.store.fetch(job["num"])
+            if method is None:
+                raise Exception(
+                    "Callback function can only called once, "
+                    "if you want to call a function for multiple times, "
+                    "please make it as a plugin api function. "
+                    "See https://imjoy.io/docs for more details."
+                )
+            args = conn.unwrap(job["args"], True)
+            result = method(*args)
+            if result is not None and inspect.isawaitable(result):
+                await result
+        except Exception:  # pylint: disable=broad-except
+            logger.error("error in method %s: %s", job["num"], traceback.format_exc())

--- a/imjoy/worker.py
+++ b/imjoy/worker.py
@@ -74,7 +74,7 @@ def handle_execute(conn, job, logger):
             else:
                 raise Exception("unsupported type")
             conn.emit({"type": "executeSuccess"})
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             traceback_error = traceback.format_exc()
             logger.error("error during execution: %s", traceback_error)
             conn.emit({"type": "executeFailure", "error": traceback_error})
@@ -95,11 +95,9 @@ def handle_method(conn, job, logger):
                 # args.append({'id': conn.id})
                 result = method(*args)
                 resolve(result)
-            except Exception as exc:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 traceback_error = traceback.format_exc()
-                logger.error(
-                    "error in method %s: %s", job["name"], traceback_error
-                )
+                logger.error("error in method %s: %s", job["name"], traceback_error)
                 reject(Exception(formatTraceback(traceback_error)))
         else:
             try:
@@ -132,11 +130,9 @@ def handle_callback(conn, job, logger):
             args = conn.unwrap(job["args"], True)
             result = method(*args)
             resolve(result)
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             traceback_error = traceback.format_exc()
-            logger.error(
-                "error in method %s: %s", job["num"], traceback_error
-            )
+            logger.error("error in method %s: %s", job["num"], traceback_error)
             reject(Exception(formatTraceback(traceback_error)))
     else:
         try:

--- a/imjoy/worker.py
+++ b/imjoy/worker.py
@@ -3,7 +3,7 @@ import inspect
 import traceback
 
 from .imjoyUtils import formatTraceback
-from .util import Registry
+from .util import Registry, make_coro
 
 # pylint: disable=unused-argument
 
@@ -126,16 +126,6 @@ def handle_callback(conn, job, logger):
             method(*args)
         except Exception:  # pylint: disable=broad-except
             logger.error("error in method %s: %s", job["num"], traceback.format_exc())
-
-
-def make_coro(func):
-    """Wrap a normal function with a coroutine."""
-
-    async def wrapper(*args, **kwargs):
-        """Run the normal function."""
-        return func(*args, **kwargs)
-
-    return wrapper
 
 
 JOB_HANDLERS_PY3 = Registry()

--- a/imjoy/worker.py
+++ b/imjoy/worker.py
@@ -3,8 +3,8 @@ import traceback
 import sys
 import time
 
-from .imjoyUtils import formatTraceback
-from .util import Registry
+from imjoyUtils import formatTraceback
+from util import Registry
 
 try:
     import queue

--- a/imjoy/worker3.py
+++ b/imjoy/worker3.py
@@ -47,11 +47,9 @@ async def handle_method_py3(conn, job, logger):
                 if result is not None and inspect.isawaitable(result):
                     result = await result
                 resolve(result)
-            except Exception as exc:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 traceback_error = traceback.format_exc()
-                logger.error(
-                    "error in method %s: %s", job["name"], traceback_error
-                )
+                logger.error("error in method %s: %s", job["name"], traceback_error)
                 reject(Exception(formatTraceback(traceback_error)))
         else:
             try:
@@ -88,11 +86,9 @@ async def handle_callback_py3(conn, job, logger):
             if result is not None and inspect.isawaitable(result):
                 result = await result
             resolve(result)
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             traceback_error = traceback.format_exc()
-            logger.error(
-                "error in method %s: %s", job["num"], traceback_error
-            )
+            logger.error("error in method %s: %s", job["num"], traceback_error)
             reject(Exception(formatTraceback(traceback_error)))
     else:
         try:

--- a/imjoy/worker3.py
+++ b/imjoy/worker3.py
@@ -3,9 +3,10 @@ import inspect
 import sys
 import traceback
 
-from .imjoyUtils import formatTraceback
-from .util import Registry, make_coro
-from .worker import JOB_HANDLERS
+from imjoyUtils import formatTraceback
+from imjoyUtils3 import make_coro
+from util import Registry
+from worker import JOB_HANDLERS
 
 # pylint: disable=unused-argument
 


### PR DESCRIPTION
* Register standalone job handler functions via decorator.
* Make connection attrs and methods non private
* Use snake-case names.
* Disable some pylint errors.
* Use super when possible.