### PR TITLE
improve error message

### DIFF
--- a/imjoy/VERSION
+++ b/imjoy/VERSION
@@ -1,4 +1,4 @@
 {
-    "version": "0.7.66",
+    "version": "0.7.67",
     "api_version": "0.1.1"
 }

--- a/imjoy/imjoyPluginEngine.py
+++ b/imjoy/imjoyPluginEngine.py
@@ -825,6 +825,9 @@ async def on_init_plugin(sid, kwargs):
                 logger.debug("message from %s", pid)
                 if kwargs["type"] == "initialized":
                     addPlugin(plugin_info, sid)
+                elif kwargs["type"] == "executeFailure":
+                    logger.info("Killing plugin %s due to exeuction failure.", pid)
+                    killPlugin(pid)
             else:
                 await sio.emit(
                     "message_from_plugin_" + secretKey,

--- a/imjoy/imjoyUtils.py
+++ b/imjoy/imjoyUtils.py
@@ -135,10 +135,9 @@ def task_worker(self, q, logger, abort):
                             raise Exception("unsupported type")
                         self.emit({"type": "executeSuccess"})
                     except Exception as e:
-                        logger.info(
-                            "error during execution: %s", traceback.format_exc()
-                        )
-                        self.emit({"type": "executeFailure", "error": repr(e)})
+                        traceback_error = traceback.format_exc()
+                        logger.info("error during execution: %s", traceback_error)
+                        self.emit({"type": "executeFailure", "error": traceback_error})
             elif d["type"] == "method":
                 interface = self._interface
                 if "pid" in d and d["pid"] is not None:
@@ -153,12 +152,11 @@ def task_worker(self, q, logger, abort):
                             result = method(*args)
                             resolve(result)
                         except Exception as e:
+                            traceback_error = traceback.format_exc()
                             logger.error(
-                                "error in method %s: %s",
-                                d["name"],
-                                traceback.format_exc(),
+                                "error in method %s: %s", d["name"], traceback_error
                             )
-                            reject(e)
+                            reject(traceback_error)
                     else:
                         try:
                             method = interface[d["name"]]
@@ -189,8 +187,9 @@ def task_worker(self, q, logger, abort):
                         result = method(*args)
                         resolve(result)
                     except Exception as e:
+                        traceback_error = traceback.format_exc()
                         logger.error(
-                            "error in method %s: %s", d["num"], traceback.format_exc()
+                            "error in method %s: %s", d["num"], traceback_error
                         )
                         reject(e)
                 else:

--- a/imjoy/imjoyUtils.py
+++ b/imjoy/imjoyUtils.py
@@ -136,7 +136,7 @@ def task_worker(self, q, logger, abort):
                         self.emit({"type": "executeSuccess"})
                     except Exception as e:
                         traceback_error = traceback.format_exc()
-                        logger.info("error during execution: %s", traceback_error)
+                        logger.error("error during execution: %s", traceback_error)
                         self.emit({"type": "executeFailure", "error": traceback_error})
             elif d["type"] == "method":
                 interface = self._interface

--- a/imjoy/imjoyUtils.py
+++ b/imjoy/imjoyUtils.py
@@ -137,7 +137,12 @@ def task_worker(self, q, logger, abort):
                     except Exception as e:
                         traceback_error = traceback.format_exc()
                         logger.error("error during execution: %s", traceback_error)
-                        self.emit({"type": "executeFailure", "error": Exception(traceback_error)})
+                        self.emit(
+                            {
+                                "type": "executeFailure",
+                                "error": Exception(traceback_error),
+                            }
+                        )
             elif d["type"] == "method":
                 interface = self._interface
                 if "pid" in d and d["pid"] is not None:

--- a/imjoy/imjoyUtils.py
+++ b/imjoy/imjoyUtils.py
@@ -70,6 +70,18 @@ def getKeyByValue(d, value):
     return None
 
 
+def formatTraceback(traceback_string):
+    formatted_lines = traceback_string.splitlines()
+    # remove the second and third line
+    formatted_lines.pop(1)
+    formatted_lines.pop(1)
+    formatted_error_string = "\n".join(formatted_lines)
+    formatted_error_string = formatted_error_string.replace(
+        'File "<string>"', "Plugin script"
+    )
+    return formatted_error_string
+
+
 class ReferenceStore:
     """Represent a reference store."""
 
@@ -137,12 +149,7 @@ def task_worker(self, q, logger, abort):
                     except Exception as e:
                         traceback_error = traceback.format_exc()
                         logger.error("error during execution: %s", traceback_error)
-                        self.emit(
-                            {
-                                "type": "executeFailure",
-                                "error": Exception(traceback_error),
-                            }
-                        )
+                        self.emit({"type": "executeFailure", "error": traceback_error})
             elif d["type"] == "method":
                 interface = self._interface
                 if "pid" in d and d["pid"] is not None:
@@ -161,7 +168,7 @@ def task_worker(self, q, logger, abort):
                             logger.error(
                                 "error in method %s: %s", d["name"], traceback_error
                             )
-                            reject(Exception(traceback_error))
+                            reject(Exception(formatTraceback(traceback_error)))
                     else:
                         try:
                             method = interface[d["name"]]
@@ -196,7 +203,7 @@ def task_worker(self, q, logger, abort):
                         logger.error(
                             "error in method %s: %s", d["num"], traceback_error
                         )
-                        reject(Exception(traceback_error))
+                        reject(Exception(formatTraceback(traceback_error)))
                 else:
                     try:
                         method = self._store.fetch(d["num"])

--- a/imjoy/imjoyUtils.py
+++ b/imjoy/imjoyUtils.py
@@ -137,7 +137,7 @@ def task_worker(self, q, logger, abort):
                     except Exception as e:
                         traceback_error = traceback.format_exc()
                         logger.error("error during execution: %s", traceback_error)
-                        self.emit({"type": "executeFailure", "error": traceback_error})
+                        self.emit({"type": "executeFailure", "error": Exception(traceback_error)})
             elif d["type"] == "method":
                 interface = self._interface
                 if "pid" in d and d["pid"] is not None:
@@ -156,7 +156,7 @@ def task_worker(self, q, logger, abort):
                             logger.error(
                                 "error in method %s: %s", d["name"], traceback_error
                             )
-                            reject(traceback_error)
+                            reject(Exception(traceback_error))
                     else:
                         try:
                             method = interface[d["name"]]
@@ -191,7 +191,7 @@ def task_worker(self, q, logger, abort):
                         logger.error(
                             "error in method %s: %s", d["num"], traceback_error
                         )
-                        reject(e)
+                        reject(Exception(traceback_error))
                 else:
                     try:
                         method = self._store.fetch(d["num"])

--- a/imjoy/imjoyUtils3.py
+++ b/imjoy/imjoyUtils3.py
@@ -42,9 +42,7 @@ async def task_worker(self, async_q, logger, abort=None):
                         self.emit({"type": "executeSuccess"})
                     except Exception as e:
                         traceback_error = traceback.format_exc()
-                        logger.info(
-                            "error during execution: %s", traceback_error
-                        )
+                        logger.info("error during execution: %s", traceback_error)
                         self.emit({"type": "executeFailure", "error": traceback_error})
             elif d["type"] == "method":
                 if d["name"] in self._interface:
@@ -61,9 +59,7 @@ async def task_worker(self, async_q, logger, abort=None):
                         except Exception as e:
                             traceback_error = traceback.format_exc()
                             logger.error(
-                                "error in method %s: %s",
-                                d["name"],
-                                traceback_error,
+                                "error in method %s: %s", d["name"], traceback_error
                             )
                             reject(traceback_error)
                     else:

--- a/imjoy/imjoyUtils3.py
+++ b/imjoy/imjoyUtils3.py
@@ -42,7 +42,7 @@ async def task_worker(self, async_q, logger, abort=None):
                         self.emit({"type": "executeSuccess"})
                     except Exception as e:
                         traceback_error = traceback.format_exc()
-                        logger.info("error during execution: %s", traceback_error)
+                        logger.error("error during execution: %s", traceback_error)
                         self.emit({"type": "executeFailure", "error": traceback_error})
             elif d["type"] == "method":
                 if d["name"] in self._interface:

--- a/imjoy/imjoyUtils3.py
+++ b/imjoy/imjoyUtils3.py
@@ -43,7 +43,12 @@ async def task_worker(self, async_q, logger, abort=None):
                     except Exception as e:
                         traceback_error = traceback.format_exc()
                         logger.error("error during execution: %s", traceback_error)
-                        self.emit({"type": "executeFailure", "error": Exception(traceback_error)})
+                        self.emit(
+                            {
+                                "type": "executeFailure",
+                                "error": Exception(traceback_error),
+                            }
+                        )
             elif d["type"] == "method":
                 if d["name"] in self._interface:
                     if "promise" in d:

--- a/imjoy/imjoyUtils3.py
+++ b/imjoy/imjoyUtils3.py
@@ -4,7 +4,7 @@ import sys
 import traceback
 import inspect
 
-from imjoyUtils import Promise
+from imjoyUtils import Promise, formatTraceback
 
 
 async def task_worker(self, async_q, logger, abort=None):
@@ -43,12 +43,8 @@ async def task_worker(self, async_q, logger, abort=None):
                     except Exception as e:
                         traceback_error = traceback.format_exc()
                         logger.error("error during execution: %s", traceback_error)
-                        self.emit(
-                            {
-                                "type": "executeFailure",
-                                "error": Exception(traceback_error),
-                            }
-                        )
+                        self.emit({"type": "executeFailure", "error": traceback_error})
+
             elif d["type"] == "method":
                 if d["name"] in self._interface:
                     if "promise" in d:
@@ -66,7 +62,7 @@ async def task_worker(self, async_q, logger, abort=None):
                             logger.error(
                                 "error in method %s: %s", d["name"], traceback_error
                             )
-                            reject(Exception(traceback_error))
+                            reject(Exception(formatTraceback(traceback_error)))
                     else:
                         try:
                             method = self._interface[d["name"]]
@@ -105,7 +101,7 @@ async def task_worker(self, async_q, logger, abort=None):
                         logger.error(
                             "error in method %s: %s", d["num"], traceback_error
                         )
-                        reject(Exception(traceback_error))
+                        reject(Exception(formatTraceback(traceback_error)))
                 else:
                     try:
                         method = self._store.fetch(d["num"])

--- a/imjoy/imjoyUtils3.py
+++ b/imjoy/imjoyUtils3.py
@@ -41,10 +41,11 @@ async def task_worker(self, async_q, logger, abort=None):
                             raise Exception("unsupported type")
                         self.emit({"type": "executeSuccess"})
                     except Exception as e:
+                        traceback_error = traceback.format_exc()
                         logger.info(
-                            "error during execution: %s", traceback.format_exc()
+                            "error during execution: %s", traceback_error
                         )
-                        self.emit({"type": "executeFailure", "error": repr(e)})
+                        self.emit({"type": "executeFailure", "error": traceback_error})
             elif d["type"] == "method":
                 if d["name"] in self._interface:
                     if "promise" in d:
@@ -58,12 +59,13 @@ async def task_worker(self, async_q, logger, abort=None):
                                 result = await result
                             resolve(result)
                         except Exception as e:
+                            traceback_error = traceback.format_exc()
                             logger.error(
                                 "error in method %s: %s",
                                 d["name"],
-                                traceback.format_exc(),
+                                traceback_error,
                             )
-                            reject(e)
+                            reject(traceback_error)
                     else:
                         try:
                             method = self._interface[d["name"]]
@@ -98,10 +100,11 @@ async def task_worker(self, async_q, logger, abort=None):
                             result = await result
                         resolve(result)
                     except Exception as e:
+                        traceback_error = traceback.format_exc()
                         logger.error(
-                            "error in method %s: %s", d["num"], traceback.format_exc()
+                            "error in method %s: %s", d["num"], traceback_error
                         )
-                        reject(e)
+                        reject(traceback_error)
                 else:
                     try:
                         method = self._store.fetch(d["num"])

--- a/imjoy/imjoyUtils3.py
+++ b/imjoy/imjoyUtils3.py
@@ -43,7 +43,7 @@ async def task_worker(self, async_q, logger, abort=None):
                     except Exception as e:
                         traceback_error = traceback.format_exc()
                         logger.error("error during execution: %s", traceback_error)
-                        self.emit({"type": "executeFailure", "error": traceback_error})
+                        self.emit({"type": "executeFailure", "error": Exception(traceback_error)})
             elif d["type"] == "method":
                 if d["name"] in self._interface:
                     if "promise" in d:
@@ -61,7 +61,7 @@ async def task_worker(self, async_q, logger, abort=None):
                             logger.error(
                                 "error in method %s: %s", d["name"], traceback_error
                             )
-                            reject(traceback_error)
+                            reject(Exception(traceback_error))
                     else:
                         try:
                             method = self._interface[d["name"]]
@@ -100,7 +100,7 @@ async def task_worker(self, async_q, logger, abort=None):
                         logger.error(
                             "error in method %s: %s", d["num"], traceback_error
                         )
-                        reject(traceback_error)
+                        reject(Exception(traceback_error))
                 else:
                     try:
                         method = self._store.fetch(d["num"])


### PR DESCRIPTION
When developing python plugin with a remote plugin engine, we cannot see much error information. This PR will improve the situation by sending traceback stack to ImJoy.

Tested with python 2 and 3