### PR TITLE
support imjoy.__version__

### DIFF
--- a/imjoy/__init__.py
+++ b/imjoy/__init__.py
@@ -1,1 +1,2 @@
 """Package the ImJoy plugin engine."""
+from .const import __version__

--- a/imjoy/connection/handler.py
+++ b/imjoy/connection/handler.py
@@ -113,7 +113,7 @@ async def on_start_terminal(eng, sid, kwargs):
                 return {
                     "success": True,
                     "exists": True,
-                    "message": "Welcome to ImJoy plugin engine terminal!",
+                    "message": f"Welcome to ImJoy Plugin Engine Terminal (v{__version__}).",
                 }
 
         if sys.platform == "linux" or sys.platform == "linux2":
@@ -123,8 +123,8 @@ async def on_start_terminal(eng, sid, kwargs):
             # OS X
             default_terminal_command = ["bash"]
         elif sys.platform == "win32":
-            # Windows...
-            default_terminal_command = ["start", "cmd"]
+            # Windows
+            default_terminal_command = ["cmd.exe"]
         else:
             default_terminal_command = ["bash"]
         cmd = kwargs.get("cmd", default_terminal_command)
@@ -135,6 +135,9 @@ async def on_start_terminal(eng, sid, kwargs):
             # this is the child process fork.
             # anything printed here will show up in the pty, including the output
             # of this subprocess
+            term_env = os.environ.copy()
+            term_env["TERM"] = "xterm-256color"
+            subprocess.run(cmd, env=term_env)
             subprocess.run(cmd)
         else:
             # this is the parent process fork.


### PR DESCRIPTION
```
Python 3.6.8 |Anaconda custom (x86_64)| (default, Dec 29 2018, 19:04:46) 
[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import imjoy
>>> imjoy.__version__
'0.8.2'
```