### PR TITLE
support gpu assignment with gputil

### DIFF
--- a/imjoy/VERSION
+++ b/imjoy/VERSION
@@ -1,4 +1,4 @@
 {
-    "version": "0.8.3",
+    "version": "0.8.4",
     "api_version": "0.1.2"
 }

--- a/imjoy/connection/handler.py
+++ b/imjoy/connection/handler.py
@@ -16,6 +16,8 @@ import traceback
 import uuid
 from urllib.parse import urlparse
 
+import GPUtil
+
 from imjoy.const import API_VERSION, NAME_SPACE, TEMPLATE_SCRIPT, __version__
 from imjoy.helper import get_psutil, killProcess, scandir
 from imjoy.plugin import (
@@ -512,6 +514,21 @@ async def on_register_client(eng, sid, kwargs):
             "processor": platform.processor(),
             "node": platform.node(),
         }
+
+        GPUs = GPUtil.getGPUs()
+        engine_info["GPUs"] = [
+            {
+                "name": gpu.name,
+                "id": gpu.id,
+                "memory_total": gpu.memoryTotal,
+                "memory_util": gpu.memoryUtil,
+                "memoryUsed": gpu.memoryUsed,
+                "driver": gpu.driver,
+                "temperature": temperature,
+                "load": gpu.load,
+            }
+            for gpu in GPUs
+        ]
 
         return {
             "success": True,

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ if sys.version_info > (3, 0):
         "numpy",
         "janus",
         "pyyaml",
+        "gputil",
     ]
     print("Trying to install psutil with pip...")
     ret = subprocess.Popen(


### PR DESCRIPTION
This PR support GPU assignment when running plugins, it requires:

1. the plugin to set `"env": [ { "type": "gputil", "options": {"limit": 1} }, "conda create ..." ]`, the options is defined by https://github.com/anderskm/gputil#main-functions
2. the requsted GPU deviceIDs will be converted into environment variables `CUDA_VISIBLE_DEVICES` and passed to the plugin process
3. when starting the plugin, if no gpu available, throw error to stop plugin execution.

For the moment, we don't check whether the number of deviceID meet the requirement of the plugin if there is at least one GPU available.

other changes:
 * rename `env_name` to `virtual_env_name`
 * show GPU information in system info