### PR TITLE
Fix venv_name None parsing

### DIFF
--- a/imjoy/helper.py
+++ b/imjoy/helper.py
@@ -274,7 +274,7 @@ def parse_env(eng, env, work_dir, default_env_name):
                     "You should provide an environment file via `conda env create -f`"
                 )
 
-    if not venv_name.strip():
+    if not venv_name or not venv_name.strip():
         venv_name = None
 
     return venv_name, envs, is_py2


### PR DESCRIPTION
- `venv_name` can be `None` or a string. We need to handle both cases.