### PR TITLE
Clean various lint warnings

### DIFF
--- a/imjoy/__main__.py
+++ b/imjoy/__main__.py
@@ -14,16 +14,16 @@ def main():
     opt = parse_cmd_line()
     if opt.dev:
         print("Running ImJoy Plugin Engine in development mode")
-        from .engine import main
+        from .engine import run
 
-        main()
+        run()
         return
 
     # add executable path to PATH
     os.environ["PATH"] = (
         os.path.split(sys.executable)[0] + os.pathsep + os.environ.get("PATH", "")
     )
-    CONDA_AVAILABLE = False
+    conda_available = False
     try:
         # for fixing CondaHTTPError:
         # https://github.com/conda/conda/issues/6064#issuecomment-458389796
@@ -33,7 +33,7 @@ def main():
         cout, _ = process.communicate()
         conda_prefix = json.loads(cout.decode("ascii"))["conda_prefix"]
         print("Found conda environment: {}".format(conda_prefix))
-        CONDA_AVAILABLE = True
+        conda_available = True
         if os.name == "nt":
             os.environ["PATH"] = (
                 os.path.join(conda_prefix, "Library", "bin")
@@ -62,9 +62,9 @@ def main():
 
         # reload to use the new version
         importlib.reload(imjoy)
-        from imjoy.engine import main
+        from imjoy.engine import run
 
-        main()
+        run()
     else:
         # running in python 2
         print("ImJoy needs to run in Python 3.6+, bootstrapping with conda")
@@ -95,7 +95,7 @@ def main():
         requirements = imjoy_requirements
         pip_cmd = "pip install -U " + " ".join(requirements)
 
-        if CONDA_AVAILABLE:
+        if conda_available:
             if sys.platform == "linux" or sys.platform == "linux2":
                 # linux
                 conda_activate = (
@@ -132,11 +132,10 @@ def main():
                         "Failed to install git/pip and dependencies "
                         "with exit code: {}".format(ret)
                     )
-                else:
-                    ret = subprocess.Popen(pip_cmd.split(), shell=False).wait()
-                    if ret != 0:
-                        print("ImJoy failed with exit code: {}".format(ret))
-                        sys.exit(2)
+                ret = subprocess.Popen(pip_cmd.split(), shell=False).wait()
+                if ret != 0:
+                    print("ImJoy failed with exit code: {}".format(ret))
+                    sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/imjoy/connection/handler.py
+++ b/imjoy/connection/handler.py
@@ -372,13 +372,12 @@ async def on_init_plugin(engine, sid, kwargs):
             )
             asyncio.run_coroutine_threadsafe(coro, eloop).result()
 
-        args = '{} "{}" --id="{}" --server={} --secret="{}" --namespace={}'.format(
+        args = '{} "{}" --id="{}" --server={} --secret="{}"'.format(
             cmd,
             TEMPLATE_SCRIPT,
             pid,
             "http://127.0.0.1:" + engine.opt.port,
             secret_key,
-            NAME_SPACE,
         )
         task_thread = threading.Thread(
             target=launch_plugin,

--- a/imjoy/connection/server.py
+++ b/imjoy/connection/server.py
@@ -255,14 +255,10 @@ async def download_file(request):  # pylint: disable=too-many-return-statements
             return web.json_response(file_list, headers=headers)
         # list the subfolder or get a file in the folder
 
-        file_path = os.path.join(
-            file_info["path"], os.sep.join(name.split("/")[1:])
-        )
+        file_path = os.path.join(file_info["path"], os.sep.join(name.split("/")[1:]))
         if not os.path.exists(file_path):
             return web.Response(
-                body="File <{file_path}> does not exist".format(
-                    file_path=file_path
-                ),
+                body="File <{file_path}> does not exist".format(file_path=file_path),
                 status=404,
             )
         if os.path.isdir(file_path):
@@ -277,9 +273,7 @@ async def download_file(request):  # pylint: disable=too-many-return-statements
             return web.json_response(file_list, headers=headers)
 
         _, file_name = os.path.split(file_path)
-        mime_type = (
-            MimeTypes().guess_type(file_name)[0] or "application/octet-stream"
-        )
+        mime_type = MimeTypes().guess_type(file_name)[0] or "application/octet-stream"
         file_size = os.path.getsize(file_path)
         headers = headers or {
             "Content-Disposition": 'inline; filename="{filename}"'.format(
@@ -289,9 +283,7 @@ async def download_file(request):  # pylint: disable=too-many-return-statements
             "Content-Length": str(file_size),
         }
         headers.update(default_headers)
-        return web.Response(
-            body=file_sender(file_path=file_path), headers=headers
-        )
+        return web.Response(body=file_sender(file_path=file_path), headers=headers)
     if file_info["type"] == "file":
         file_path = file_info["path"]
         if name != file_info["name"]:

--- a/imjoy/connection/server.py
+++ b/imjoy/connection/server.py
@@ -215,7 +215,7 @@ async def upload_file(request):
         return web.Response(body=f"Failed to upload, error: {exc}", status=404)
 
 
-async def download_file(request):
+async def download_file(request):  # pylint: disable=too-many-return-statements
     """Download file."""
     engine = request.app[ENGINE]
     generated_urls = engine.store.generated_urls
@@ -244,55 +244,55 @@ async def download_file(request):
                     ),
                     status=404,
                 )
-            else:
-                file_list = scandir(folder_path, "file", False)
-                headers = headers or {
-                    "Content-Disposition": 'inline; filename="{filename}"'.format(
-                        filename=name
-                    )
-                }
-                headers.update(default_headers)
-                return web.json_response(file_list, headers=headers)
+
+            file_list = scandir(folder_path, "file", False)
+            headers = headers or {
+                "Content-Disposition": 'inline; filename="{filename}"'.format(
+                    filename=name
+                )
+            }
+            headers.update(default_headers)
+            return web.json_response(file_list, headers=headers)
         # list the subfolder or get a file in the folder
-        else:
-            file_path = os.path.join(
-                file_info["path"], os.sep.join(name.split("/")[1:])
+
+        file_path = os.path.join(
+            file_info["path"], os.sep.join(name.split("/")[1:])
+        )
+        if not os.path.exists(file_path):
+            return web.Response(
+                body="File <{file_path}> does not exist".format(
+                    file_path=file_path
+                ),
+                status=404,
             )
-            if not os.path.exists(file_path):
-                return web.Response(
-                    body="File <{file_path}> does not exist".format(
-                        file_path=file_path
-                    ),
-                    status=404,
+        if os.path.isdir(file_path):
+            _, folder_name = os.path.split(file_path)
+            file_list = scandir(file_path, "file", False)
+            headers = headers or {
+                "Content-Disposition": 'inline; filename="{filename}"'.format(
+                    filename=folder_name
                 )
-            if os.path.isdir(file_path):
-                _, folder_name = os.path.split(file_path)
-                file_list = scandir(file_path, "file", False)
-                headers = headers or {
-                    "Content-Disposition": 'inline; filename="{filename}"'.format(
-                        filename=folder_name
-                    )
-                }
-                headers.update(default_headers)
-                return web.json_response(file_list, headers=headers)
-            else:
-                _, file_name = os.path.split(file_path)
-                mime_type = (
-                    MimeTypes().guess_type(file_name)[0] or "application/octet-stream"
-                )
-                file_size = os.path.getsize(file_path)
-                headers = headers or {
-                    "Content-Disposition": 'inline; filename="{filename}"'.format(
-                        filename=file_name
-                    ),
-                    "Content-Type": mime_type,
-                    "Content-Length": str(file_size),
-                }
-                headers.update(default_headers)
-                return web.Response(
-                    body=file_sender(file_path=file_path), headers=headers
-                )
-    elif file_info["type"] == "file":
+            }
+            headers.update(default_headers)
+            return web.json_response(file_list, headers=headers)
+
+        _, file_name = os.path.split(file_path)
+        mime_type = (
+            MimeTypes().guess_type(file_name)[0] or "application/octet-stream"
+        )
+        file_size = os.path.getsize(file_path)
+        headers = headers or {
+            "Content-Disposition": 'inline; filename="{filename}"'.format(
+                filename=file_name
+            ),
+            "Content-Type": mime_type,
+            "Content-Length": str(file_size),
+        }
+        headers.update(default_headers)
+        return web.Response(
+            body=file_sender(file_path=file_path), headers=headers
+        )
+    if file_info["type"] == "file":
         file_path = file_info["path"]
         if name != file_info["name"]:
             raise web.HTTPForbidden(text="File name does not match server record!")
@@ -313,8 +313,8 @@ async def download_file(request):
         }
         headers.update(default_headers)
         return web.Response(body=file_sender(file_path=file_path), headers=headers)
-    else:
-        raise web.HTTPForbidden(text="Unsupported file type: " + file_info["type"])
+
+    raise web.HTTPForbidden(text="Unsupported file type: " + file_info["type"])
 
 
 async def on_startup(app):

--- a/imjoy/engine.py
+++ b/imjoy/engine.py
@@ -28,7 +28,7 @@ class Engine:
         self.conn.start()
 
 
-def main():
+def run():
     """Run app."""
     logging.basicConfig(stream=sys.stdout)
     logger = logging.getLogger("ImJoyPluginEngine")
@@ -42,4 +42,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    run()

--- a/imjoy/plugin.py
+++ b/imjoy/plugin.py
@@ -458,19 +458,14 @@ def launch_plugin(
         stop_callback(True, outputs)
         return True
 
-    logging_callback(
-        f"Plugin process exited with code {exit_code}", type="error"
-    )
+    logging_callback(f"Plugin process exited with code {exit_code}", type="error")
     logger.error(
-        "Error occured during terminating a process.\n"
-        "Command: %s\nExit code: %s",
+        "Error occured during terminating a process.\n" "Command: %s\nExit code: %s",
         args,
         exit_code,
     )
     errors = errors or ""
-    stop_callback(
-        False, f"{errors}\nPlugin process exited with code {exit_code}"
-    )
+    stop_callback(False, f"{errors}\nPlugin process exited with code {exit_code}")
     return False
 
 

--- a/imjoy/util/__init__.py
+++ b/imjoy/util/__init__.py
@@ -44,7 +44,7 @@ def parse_repos(requirements, work_dir):
                 typ, libs = req_parts[0], ":".join(req_parts[1:])
                 typ, libs = typ.strip(), libs.strip()
                 libs = [l.strip() for l in libs.split(" ") if l.strip() != ""]
-                if typ == "repo" and len(libs) > 0:
+                if typ == "repo" and libs:
                     name = libs[0].split("/")[-1].replace(".git", "")
                     repo = {
                         "url": libs[0],

--- a/imjoy/worker_template.py
+++ b/imjoy/worker_template.py
@@ -336,9 +336,7 @@ class PluginConnection:
                 val = a_object[key]
                 if isinstance(val, (dict, list)):
                     if isarray:
-                        b_object.append(
-                            self._decode(val, callback_id, with_promise)
-                        )
+                        b_object.append(self._decode(val, callback_id, with_promise))
                     else:
                         b_object[key] = self._decode(val, callback_id, with_promise)
         return b_object

--- a/imjoy/worker_template.py
+++ b/imjoy/worker_template.py
@@ -78,10 +78,8 @@ class PluginConnection:
         job_queue=None,
         loop=None,
         worker=None,
-        namespace="/",
         work_dir=None,
         daemon=False,
-        api=None,
     ):
         """Set up connection."""
         if work_dir is None or work_dir == "" or work_dir == ".":
@@ -104,8 +102,8 @@ class PluginConnection:
         self.emit = emit
 
         self.local = {}
-        _remote = dotdict()
-        self._set_local_api(_remote)
+        self._remote = dotdict()
+        self._set_local_api(self._remote)
         self.interface = {}
         self.plugin_interfaces = {}
         self.remote_set = False
@@ -127,6 +125,7 @@ class PluginConnection:
         socket_io.on("disconnect", on_disconnect)
         self.abort = threading.Event()
         self.worker = worker
+        self.sync_q = None
 
     def wait_forever(self):
         """Wait forever."""
@@ -326,23 +325,23 @@ class PluginConnection:
             else:
                 b_object = a_object["__value__"]
             return b_object
-        else:
-            if isinstance(a_object, tuple):
-                a_object = list(a_object)
-            isarray = isinstance(a_object, list)
-            b_object = [] if isarray else dotdict()
-            keys = range(len(a_object)) if isarray else a_object.keys()
-            for key in keys:
-                if isarray or key in a_object:
-                    val = a_object[key]
-                    if isinstance(val, (dict, list)):
-                        if isarray:
-                            b_object.append(
-                                self._decode(val, callback_id, with_promise)
-                            )
-                        else:
-                            b_object[key] = self._decode(val, callback_id, with_promise)
-            return b_object
+
+        if isinstance(a_object, tuple):
+            a_object = list(a_object)
+        isarray = isinstance(a_object, list)
+        b_object = [] if isarray else dotdict()
+        keys = range(len(a_object)) if isarray else a_object.keys()
+        for key in keys:
+            if isarray or key in a_object:
+                val = a_object[key]
+                if isinstance(val, (dict, list)):
+                    if isarray:
+                        b_object.append(
+                            self._decode(val, callback_id, with_promise)
+                        )
+                    else:
+                        b_object[key] = self._decode(val, callback_id, with_promise)
+        return b_object
 
     def _wrap(self, args):
         """Wrap arguments."""
@@ -405,8 +404,9 @@ class PluginConnection:
         """Return remote method."""
 
         def remote_method(*arguments, **kwargs):
+            """Run remote method."""
             # wrap keywords to a dictionary and pass to the first argument
-            if len(arguments) == 0 and len(kwargs) > 0:
+            if not arguments and kwargs:
                 arguments = [kwargs]
 
             def pfunc(resolve, reject):
@@ -423,8 +423,7 @@ class PluginConnection:
 
             if PYTHON3:
                 return FuturePromise(pfunc, self.loop)
-            else:
-                return Promise(pfunc)
+            return Promise(pfunc)
 
         remote_method.__remote_method = True
         return remote_method
@@ -435,7 +434,7 @@ class PluginConnection:
 
             def remote_callback(*arguments, **kwargs):
                 # wrap keywords to a dictionary and pass to the first argument
-                if len(arguments) == 0 and len(kwargs) > 0:
+                if not arguments and kwargs:
                     arguments = [kwargs]
 
                 def pfunc(resolve, reject):
@@ -454,16 +453,15 @@ class PluginConnection:
 
                 if PYTHON3:
                     return FuturePromise(pfunc, self.loop)
-                else:
-                    return Promise(pfunc)
+                return Promise(pfunc)
 
         else:
 
             def remote_callback(*arguments, **kwargs):
                 # wrap keywords to a dictionary and pass to the first argument
-                if len(arguments) == 0 and len(kwargs) > 0:
+                if not arguments and kwargs:
                     arguments = [kwargs]
-                ret = self.emit(
+                self.emit(
                     {
                         "type": "callback",
                         "id": id_,
@@ -472,14 +470,13 @@ class PluginConnection:
                         "args": self._wrap(arguments),
                     }
                 )
-                return ret
 
         return remote_callback
 
     def set_remote(self, api):
         """Set remote."""
         _remote = dotdict()
-        for i in range(len(api)):
+        for i, _ in enumerate(api):
             if isinstance(api[i], dict) and "name" in api[i]:
                 name = api[i]["name"]
                 data = api[i].get("data", None)
@@ -550,7 +547,6 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--id", type=str, required=True, help="plugin id")
     parser.add_argument("--secret", type=str, required=True, help="plugin secret")
-    parser.add_argument("--namespace", type=str, default="/", help="socketio namespace")
     parser.add_argument(
         "--work_dir", type=str, default=".", help="plugin working directory"
     )
@@ -584,11 +580,12 @@ def main():
     plugin_conn = PluginConnection(
         opt.id,
         opt.secret,
-        server=opt.server,
-        work_dir=opt.work_dir,
+        opt.server,
         job_queue=job_queue,
         loop=event_loop,
         worker=task_worker,
+        work_dir=opt.work_dir,
+        daemon=opt.daemon,
     )
     plugin_conn.wait_forever()
 

--- a/imjoy/worker_utils.py
+++ b/imjoy/worker_utils.py
@@ -29,6 +29,7 @@ def debounce(secs):
                 result = func(*args, **kwargs)
                 store["t"] = time.time()
                 return result
+            return None
 
         return wrapped
 
@@ -96,7 +97,8 @@ class ReferenceStore:
         """Set up store."""
         self._store = {}
 
-    def _gen_id(self):
+    @staticmethod
+    def _gen_id():
         """Generate an id."""
         return str(uuid.uuid4())
 
@@ -119,7 +121,7 @@ class ReferenceStore:
         return obj
 
 
-class Promise(object):
+class Promise(object):  # pylint: disable=useless-object-inheritance
     """Represent a promise."""
 
     def __init__(self, pfunc):


### PR DESCRIPTION
- Fix pylint no else return.
- Fix pylint unused argument.
- Fix bad variable naming, eg incorrect casing.
- Fix pylint redefined outer name.
- FIx pylint len as condition.
- Disable some warnings when we want to keep it as is, eg `# pylint: disable=redefined-builtin`.