### PR TITLE
upgrade from pip instead of github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN conda update -y conda && \
     conda update pip && \
     conda install -y python=3.6 numpy scipy git psutil && \
     pip install scikit-image Pillow && \
-    pip install git+https://github.com/oeway/ImJoy-Engine#egg=imjoy && \
+    pip install imjoy && \
     conda clean -y --tarballs
 
 ENTRYPOINT ["python", "-m", "imjoy", "--serve", "--host=0.0.0.0"]

--- a/imjoy/VERSION
+++ b/imjoy/VERSION
@@ -1,4 +1,4 @@
 {
-    "version": "0.8.9",
+    "version": "0.8.11",
     "api_version": "0.1.2"
 }

--- a/imjoy/__main__.py
+++ b/imjoy/__main__.py
@@ -52,10 +52,7 @@ def main():
         # running in python 3
         print("Upgrading ImJoy Plugin Engine")
         ret = subprocess.Popen(
-            "pip install -U "
-            "imjoy".split(),
-            env=os.environ.copy(),
-            shell=False,
+            "pip install -U imjoy".split(), env=os.environ.copy(), shell=False
         ).wait()
         if ret != 0:
             print("Failed to upgrade ImJoy Plugin Engine")

--- a/imjoy/__main__.py
+++ b/imjoy/__main__.py
@@ -53,7 +53,7 @@ def main():
         print("Upgrading ImJoy Plugin Engine")
         ret = subprocess.Popen(
             "pip install -U "
-            "git+https://github.com/oeway/ImJoy-Engine#egg=imjoy".split(),
+            "imjoy".split(),
             env=os.environ.copy(),
             shell=False,
         ).wait()
@@ -71,7 +71,7 @@ def main():
         imjoy_requirements = [
             "aiohttp",
             "aiohttp_cors",
-            "git+https://github.com/oeway/ImJoy-Engine#egg=imjoy",
+            "imjoy",
             "gputil",
             "psutil",
             "python-socketio[asyncio_client]",

--- a/utils/ImJoyEngine.ps1
+++ b/utils/ImJoyEngine.ps1
@@ -23,7 +23,7 @@ $CondaDeps="numpy","scipy", "git" # some examples
 
 # Dependencies installed with pip instead
 # Comment out the next line if no PyPi dependencies
-$PyPiPackage="git+https://github.com/oeway/ImJoy-Engine#egg=imjoy"
+$PyPiPackage="imjoy"
 
 # Local packages to install
 # Useful if your application is not in PyPi

--- a/utils/ImJoyEngine.sh
+++ b/utils/ImJoyEngine.sh
@@ -34,5 +34,5 @@ if [ "$condaPath" = "" ]; then
   $HOME/ImJoyApp/bin/python -m imjoy "$@"
 else
 condaRoot=`dirname "$condaPath"`
-$condaRoot/python -m imjoy "$@" || pip install git+https://github.com/oeway/ImJoy-Engine#egg=imjoy && $condaRoot/python -m imjoy "$@"
+$condaRoot/python -m imjoy "$@" || pip install imjoy --upgrade && $condaRoot/python -m imjoy "$@"
 fi

--- a/utils/OSX_Install.sh
+++ b/utils/OSX_Install.sh
@@ -13,7 +13,7 @@ CondaDeps="numpy scipy git"
 
 # Install the package from PyPi
 # Comment out next line if installing locally
-PyPiPackage="git+https://github.com/oeway/ImJoy-Engine#egg=imjoy"
+PyPiPackage="imjoy"
 
 # Local packages to install
 # Useful if your application is not in PyPi


### PR DESCRIPTION
Currently, ImJoy-Engine will automatically upgrade from github, which can easily break due to the ongoing development on github. A more stable way is to switch to the auto-upgrade source to pip which suppose to be more stable.

Fixes https://github.com/oeway/ImJoy/issues/186