### PR TITLE
User workers as root package for workers

### DIFF
--- a/imjoy/VERSION
+++ b/imjoy/VERSION
@@ -1,4 +1,4 @@
 {
-    "version": "0.8.13",
+    "version": "0.8.14",
     "api_version": "0.1.2"
 }

--- a/imjoy/runners/subprocess.py
+++ b/imjoy/runners/subprocess.py
@@ -68,11 +68,10 @@ async def on_init_plugin(engine, sid, kwargs):
             os.makedirs(work_dir)
         plugin_env = os.environ.copy()
         plugin_env["WORK_DIR"] = work_dir
-        imjoy_path = HERE.resolve()
-        if "PYTHONPATH" in plugin_env:
-            plugin_env['PYTHONPATH'] = imjoy_path + os.path.pathsep + plugin_env['PYTHONPATH']
-        else:
-            plugin_env['PYTHONPATH'] = imjoy_path
+        imjoy_path = str(HERE.resolve())
+        plugin_env["PYTHONPATH"] = (
+            imjoy_path + os.path.pathsep + plugin_env.get("PYTHONPATH", "")
+        )
 
         logger.info(
             "Initialize the plugin, name=%s, id=%s, cmd=%s, workspace=%s",

--- a/imjoy/workers/python3_client.py
+++ b/imjoy/workers/python3_client.py
@@ -7,9 +7,9 @@ import traceback
 
 import janus
 
-from imjoy.workers.utils import format_traceback, Registry
-from imjoy.workers.utils3 import make_coro
-from imjoy.workers.python_client import BaseClient, JOB_HANDLERS
+from workers.utils import format_traceback, Registry
+from workers.utils3 import make_coro
+from workers.python_client import BaseClient, JOB_HANDLERS
 
 # pylint: disable=unused-argument, redefined-outer-name
 

--- a/imjoy/workers/python3_client.py
+++ b/imjoy/workers/python3_client.py
@@ -7,9 +7,9 @@ import traceback
 
 import janus
 
-from workers.utils import format_traceback, Registry
-from workers.utils3 import make_coro
-from workers.python_client import BaseClient, JOB_HANDLERS
+from .utils import format_traceback, Registry
+from .utils3 import make_coro
+from .python_client import BaseClient, JOB_HANDLERS
 
 # pylint: disable=unused-argument, redefined-outer-name
 

--- a/imjoy/workers/python_client.py
+++ b/imjoy/workers/python_client.py
@@ -6,7 +6,7 @@ import time
 
 import socketio
 
-from workers.utils import format_traceback, Registry
+from .utils import format_traceback, Registry
 
 try:
     import queue

--- a/imjoy/workers/python_client.py
+++ b/imjoy/workers/python_client.py
@@ -6,7 +6,7 @@ import time
 
 import socketio
 
-from imjoy.workers.utils import format_traceback, Registry
+from workers.utils import format_traceback, Registry
 
 try:
     import queue

--- a/imjoy/workers/python_worker.py
+++ b/imjoy/workers/python_worker.py
@@ -9,20 +9,16 @@ import threading
 from functools import reduce
 from types import ModuleType
 
-worker_path = os.path.dirname(os.path.normpath(os.path.join(__file__, "..")))
-if worker_path not in sys.path:
-    sys.path.insert(0, worker_path)
-
-from workers.utils import ReferenceStore, debounce, dotdict, get_psutil, set_interval
+from .utils import ReferenceStore, debounce, dotdict, get_psutil, set_interval
 
 if sys.version_info >= (3, 0):
-    from workers.utils3 import FuturePromise
-    from workers.python3_client import AsyncClient
+    from .utils3 import FuturePromise
+    from .python3_client import AsyncClient
 
     PYTHON3 = True
 else:
-    from workers.utils import Promise
-    from workers.python_client import Client
+    from .utils import Promise
+    from .python_client import Client
 
     PYTHON3 = False
 

--- a/imjoy/workers/python_worker.py
+++ b/imjoy/workers/python_worker.py
@@ -9,6 +9,13 @@ import threading
 from functools import reduce
 from types import ModuleType
 
+if "" not in sys.path:
+    sys.path.insert(0, "")
+
+imjoy_path = os.path.dirname(os.path.normpath(os.path.join(__file__, '..')))
+if imjoy_path not in sys.path:
+    sys.path.insert(0, imjoy_path)
+
 from imjoy.workers.utils import (
     ReferenceStore,
     debounce,
@@ -494,15 +501,6 @@ def main():
 
     opt = parser.parse_args()
 
-    # TODO: We can probably remove this since the script directory will be first in sys.path.
-    if "" not in sys.path:
-        sys.path.insert(0, "")
-
-    imjoy_path = os.path.dirname(os.path.normpath(__file__))
-    if imjoy_path not in sys.path:
-        sys.path.insert(0, imjoy_path)
-
-    # ENDTODO
 
     logging.basicConfig(stream=sys.stdout)
     logger.setLevel(logging.INFO)

--- a/imjoy/workers/python_worker.py
+++ b/imjoy/workers/python_worker.py
@@ -9,8 +9,6 @@ import threading
 from functools import reduce
 from types import ModuleType
 
-if "" not in sys.path:
-    sys.path.insert(0, "")
 
 imjoy_path = os.path.dirname(os.path.normpath(os.path.join(__file__, '..')))
 if imjoy_path not in sys.path:

--- a/imjoy/workers/python_worker.py
+++ b/imjoy/workers/python_worker.py
@@ -9,12 +9,11 @@ import threading
 from functools import reduce
 from types import ModuleType
 
+worker_path = os.path.dirname(os.path.normpath(os.path.join(__file__, '..')))
+if worker_path not in sys.path:
+    sys.path.insert(0, worker_path)
 
-imjoy_path = os.path.dirname(os.path.normpath(os.path.join(__file__, '..')))
-if imjoy_path not in sys.path:
-    sys.path.insert(0, imjoy_path)
-
-from imjoy.workers.utils import (
+from workers.utils import (
     ReferenceStore,
     debounce,
     dotdict,
@@ -23,13 +22,13 @@ from imjoy.workers.utils import (
 )
 
 if sys.version_info >= (3, 0):
-    from imjoy.workers.utils3 import FuturePromise
-    from imjoy.workers.python3_client import AsyncClient
+    from workers.utils3 import FuturePromise
+    from workers.python3_client import AsyncClient
 
     PYTHON3 = True
 else:
-    from imjoy.workers.utils import Promise
-    from imjoy.workers.python_client import Client
+    from workers.utils import Promise
+    from workers.python_client import Client
 
     PYTHON3 = False
 

--- a/imjoy/workers/python_worker.py
+++ b/imjoy/workers/python_worker.py
@@ -9,17 +9,11 @@ import threading
 from functools import reduce
 from types import ModuleType
 
-worker_path = os.path.dirname(os.path.normpath(os.path.join(__file__, '..')))
+worker_path = os.path.dirname(os.path.normpath(os.path.join(__file__, "..")))
 if worker_path not in sys.path:
     sys.path.insert(0, worker_path)
 
-from workers.utils import (
-    ReferenceStore,
-    debounce,
-    dotdict,
-    get_psutil,
-    set_interval,
-)
+from workers.utils import ReferenceStore, debounce, dotdict, get_psutil, set_interval
 
 if sys.version_info >= (3, 0):
     from workers.utils3 import FuturePromise
@@ -497,7 +491,6 @@ def main():
     parser.add_argument("--debug", action="store_true", help="debug mode")
 
     opt = parser.parse_args()
-
 
     logging.basicConfig(stream=sys.stdout)
     logger.setLevel(logging.INFO)

--- a/imjoy/workers/utils3.py
+++ b/imjoy/workers/utils3.py
@@ -1,7 +1,7 @@
 """Provide utils for Python 3 plugins."""
 import asyncio
 
-from workers.utils import Promise
+from .utils import Promise
 
 
 def make_coro(func):

--- a/imjoy/workers/utils3.py
+++ b/imjoy/workers/utils3.py
@@ -1,7 +1,7 @@
 """Provide utils for Python 3 plugins."""
 import asyncio
 
-from imjoy.workers.utils import Promise
+from workers.utils import Promise
 
 
 def make_coro(func):


### PR DESCRIPTION
This is a fix for importing issue happened when imjoy is not installed in the plugin environment, the plugin fails to start because there is no imjoy module found.

The bug is reported by @muellerflorian 