### PR TITLE
Simplify requirements

### DIFF
--- a/imjoy/VERSION
+++ b/imjoy/VERSION
@@ -1,4 +1,4 @@
 {
-    "version": "0.8.14",
+    "version": "0.8.15",
     "api_version": "0.1.2"
 }

--- a/imjoy/__main__.py
+++ b/imjoy/__main__.py
@@ -66,7 +66,6 @@ def main():
                         "please try to setup an environment with gcc support."
                     )
 
-    # Make sure git is installed
     import distutils.spawn
 
     if distutils.spawn.find_executable("git") is None:
@@ -82,7 +81,6 @@ def main():
         elif not opt.freeze:
             print("git not found, unable to install it because conda is not available")
 
-    # Make sure pip is installed
     if distutils.spawn.find_executable("pip") is None:
         pip_available = False
         if not opt.freeze and conda_available:

--- a/imjoy/__main__.py
+++ b/imjoy/__main__.py
@@ -66,9 +66,9 @@ def main():
                         "please try to setup an environment with gcc support."
                     )
 
-    
     # Make sure git is installed
     import distutils.spawn
+
     if distutils.spawn.find_executable("git") is None:
         if not opt.freeze and conda_available:
             print("git not found, trying to install with conda")
@@ -78,10 +78,10 @@ def main():
                 raise Exception(
                     "Failed to install git/pip and dependencies "
                     "with exit code: {}".format(ret)
-            )
+                )
         elif not opt.freeze:
-            print('git not found, unable to install it because conda is not available')
-    
+            print("git not found, unable to install it because conda is not available")
+
     # Make sure pip is installed
     if distutils.spawn.find_executable("pip") is None:
         pip_available = False
@@ -93,9 +93,9 @@ def main():
                 raise Exception(
                     "Failed to install git/pip and dependencies "
                     "with exit code: {}".format(ret)
-            )
+                )
         elif not opt.freeze:
-            print('pip not found, unable to install it because conda is not available')
+            print("pip not found, unable to install it because conda is not available")
     else:
         pip_available = True
 
@@ -104,10 +104,14 @@ def main():
             # running in python 3
             print("Upgrading ImJoy Plugin Engine")
             ret = subprocess.Popen(
-                "pip install -U imjoy[engine]".split(), env=os.environ.copy(), shell=False
+                "pip install -U imjoy[engine]".split(),
+                env=os.environ.copy(),
+                shell=False,
             ).wait()
             if ret != 0:
                 print("Failed to upgrade ImJoy Plugin Engine")
+        elif not opt.freeze:
+            print("Failed to upgrade the engine because pip was not found.")
 
         # reload to use the new version
         import imjoy
@@ -137,7 +141,6 @@ def main():
                 )
             pip_cmd = "pip install -U imjoy[engine]"
 
-
             if sys.platform == "linux" or sys.platform == "linux2":
                 # linux
                 conda_activate = (
@@ -152,15 +155,18 @@ def main():
             else:
                 conda_activate = "conda activate {}"
 
-            pip_cmd = conda_activate.format(" imjoy && " + pip_cmd + " && python -m imjoy")
+            pip_cmd = conda_activate.format(
+                " imjoy && " + pip_cmd + " && python -m imjoy"
+            )
             ret = subprocess.Popen(pip_cmd.split(), shell=False).wait()
             if ret != 0:
                 raise Exception(
                     "Failed to install and start ImJoy, exit code: {}".format(ret)
                 )
         else:
-            raise Exception("It seems you are trying to run ImJoy Engine in Python 2, but it requires Python 3.6+ (with conda).")
-    
+            raise Exception(
+                "It seems you are trying to run ImJoy Engine in Python 2, but it requires Python 3.6+ (with conda)."
+            )
 
 
 if __name__ == "__main__":

--- a/imjoy/__main__.py
+++ b/imjoy/__main__.py
@@ -14,6 +14,7 @@ def main():
     if opt.dev:
         print("Running ImJoy Plugin Engine in development mode")
         from .engine import run
+
         run()
         return
 
@@ -72,6 +73,7 @@ def main():
 
         # reload to use the new version
         import imjoy
+
         importlib.reload(imjoy)
         from imjoy.engine import run
 
@@ -95,7 +97,7 @@ def main():
                 "Otherwise, please make sure you are running in a conda environment"
             )
         pip_cmd = "pip install -U imjoy[engine]"
-        
+
         if conda_available:
             if sys.platform == "linux" or sys.platform == "linux2":
                 # linux

--- a/imjoy/runners/subprocess.py
+++ b/imjoy/runners/subprocess.py
@@ -637,7 +637,7 @@ def launch_plugin(
         default_virtual_env = default_virtual_env.replace(" ", "_")
         venv_name, envs, is_py2 = parse_env(engine, env, work_dir, default_virtual_env)
         environment_variables = {}
-        default_requirements = ["imjoy[worker]"]
+        default_requirements = ["imjoy[worker]==" + __version__]
         default_reqs_cmds = parse_requirements(
             default_requirements, conda=opt.conda_available
         )

--- a/imjoy/runners/subprocess.py
+++ b/imjoy/runners/subprocess.py
@@ -71,12 +71,12 @@ async def on_init_plugin(engine, sid, kwargs):
             )
             worker_module = "workers.python_worker"
             logger.debug(
-                "Adding imjoy package directory to PYTHONPATH, will run module `workers.python_worker`"
+                "Adding imjoy package directory to PYTHONPATH, will run module `workers.python_worker`."
             )
         else:
             worker_module = "imjoy.workers.python_worker"
             logger.debug(
-                "Will use workers from pip package, will run module `imjoy.workers.python_worker`"
+                "Will run module `imjoy.workers.python_worker` from installed imjoy package."
             )
 
         logger.info(

--- a/imjoy/runners/subprocess.py
+++ b/imjoy/runners/subprocess.py
@@ -71,12 +71,12 @@ async def on_init_plugin(engine, sid, kwargs):
             )
             worker_module = "workers.python_worker"
             logger.debug(
-                "Adding imjoy package directory to PYTHONPATH, will run module `workers.python_worker`."
+                "ImJoy package directory was added to PYTHONPATH, will run module `workers.python_worker`."
             )
         else:
             worker_module = "imjoy.workers.python_worker"
             logger.debug(
-                "Will run module `imjoy.workers.python_worker` from installed imjoy package."
+                "Will run module `imjoy.workers.python_worker` from installed ImJoy package."
             )
 
         logger.info(

--- a/imjoy/runners/subprocess.py
+++ b/imjoy/runners/subprocess.py
@@ -69,11 +69,15 @@ async def on_init_plugin(engine, sid, kwargs):
             plugin_env["PYTHONPATH"] = (
                 imjoy_path + os.path.pathsep + plugin_env.get("PYTHONPATH", "")
             )
-            worker_module = 'workers.python_worker'
-            logger.debug('Adding imjoy package directory to PYTHONPATH, will run module `workers.python_worker`')
+            worker_module = "workers.python_worker"
+            logger.debug(
+                "Adding imjoy package directory to PYTHONPATH, will run module `workers.python_worker`"
+            )
         else:
-            worker_module = 'imjoy.workers.python_worker'
-            logger.debug('Will use workers from pip package, will run module `imjoy.workers.python_worker`')
+            worker_module = "imjoy.workers.python_worker"
+            logger.debug(
+                "Will use workers from pip package, will run module `imjoy.workers.python_worker`"
+            )
 
         logger.info(
             "Initialize the plugin, name=%s, id=%s, cmd=%s, workspace=%s",

--- a/imjoy/runners/subprocess.py
+++ b/imjoy/runners/subprocess.py
@@ -24,10 +24,6 @@ from .helper import (
     run_process,
 )
 
-DEFAULT_REQUIREMENTS_PY2 = ["numpy", "python-socketio[client]"]
-DEFAULT_REQUIREMENTS_PY3 = ["numpy", "python-socketio[client]", "janus"]
-REQ_PSUTIL = ["psutil"]
-REQ_PSUTIL_CONDA = ["conda:psutil"]
 MAX_ATTEMPTS = 1000
 
 
@@ -68,10 +64,16 @@ async def on_init_plugin(engine, sid, kwargs):
             os.makedirs(work_dir)
         plugin_env = os.environ.copy()
         plugin_env["WORK_DIR"] = work_dir
-        imjoy_path = str(HERE.resolve())
-        plugin_env["PYTHONPATH"] = (
-            imjoy_path + os.path.pathsep + plugin_env.get("PYTHONPATH", "")
-        )
+        if engine.opt.dev:
+            imjoy_path = str(HERE.resolve())
+            plugin_env["PYTHONPATH"] = (
+                imjoy_path + os.path.pathsep + plugin_env.get("PYTHONPATH", "")
+            )
+            worker_module = 'workers.python_worker'
+            logger.debug('Adding imjoy package directory to PYTHONPATH, will run module `workers.python_worker`')
+        else:
+            worker_module = 'imjoy.workers.python_worker'
+            logger.debug('Will use workers from pip package, will run module `imjoy.workers.python_worker`')
 
         logger.info(
             "Initialize the plugin, name=%s, id=%s, cmd=%s, workspace=%s",
@@ -191,8 +193,8 @@ async def on_init_plugin(engine, sid, kwargs):
             )
             asyncio.run_coroutine_threadsafe(coro, eloop).result()
 
-        args = '{} -m workers.python_worker --id="{}" --server={} --secret="{}"'.format(
-            cmd, pid, "http://127.0.0.1:" + engine.opt.port, secret_key
+        args = '{} -m {} --id="{}" --server={} --secret="{}"'.format(
+            cmd, worker_module, pid, "http://127.0.0.1:" + engine.opt.port, secret_key
         )
         task_thread = threading.Thread(
             target=launch_plugin,
@@ -631,9 +633,7 @@ def launch_plugin(
         default_virtual_env = default_virtual_env.replace(" ", "_")
         venv_name, envs, is_py2 = parse_env(engine, env, work_dir, default_virtual_env)
         environment_variables = {}
-        default_requirements = (
-            DEFAULT_REQUIREMENTS_PY2 if is_py2 else DEFAULT_REQUIREMENTS_PY3
-        )
+        default_requirements = ["imjoy[worker]"]
         default_reqs_cmds = parse_requirements(
             default_requirements, conda=opt.conda_available
         )
@@ -653,7 +653,7 @@ def launch_plugin(
             """Notify when an install process command has finished."""
             logger.debug("Finished running (pid=%s): %s", pid, cmd)
             nonlocal progress
-            progress += int(70 / (len(envs) + len(reqs_cmds) + len(REQ_PSUTIL)))
+            progress += int(70 / (len(envs) + len(reqs_cmds)))
             logging_callback(progress, type="progress")
 
         for _env in envs:
@@ -720,25 +720,6 @@ def launch_plugin(
             process_finish,
             logging_callback,
         )
-
-        if not opt.freeze:
-            psutil_cmds = parse_requirements(REQ_PSUTIL)
-            logger.info("Running requirements commands: %s", psutil_cmds)
-            code, _ = run_commands(
-                plugin_env, work_dir, psutil_cmds, process_start, process_finish
-            )
-        if not opt.freeze and code and opt.conda_available and venv_name is not None:
-            logger.info("Failed installing psutil with pip, trying conda")
-            psutil_cmds = parse_requirements(
-                REQ_PSUTIL_CONDA, conda=opt.conda_available
-            )
-            psutil_cmds = apply_conda_activate(
-                psutil_cmds, opt.conda_activate, venv_name
-            )
-            logger.info("Running requirements commands: %s", psutil_cmds)
-            code, _ = run_commands(
-                plugin_env, work_dir, psutil_cmds, process_start, process_finish
-            )
 
     except Exception:  # pylint: disable=broad-except
         error_traceback = traceback.format_exc()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ aiohttp==3.5.4
 aiohttp_cors==0.7.0
 gputil==1.4.0
 psutil==5.6.2
-python-socketio[asyncio_client]==4.0.1
+python-socketio[client]==4.0.1
 pyyaml==5.1

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 """Set up the ImJoy-Engine imjoy package."""
 import os
-import sys
-import subprocess
 from setuptools import setup, find_packages
 import json
 

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,8 @@ DESCRIPTION = (
     "or remotely from ImJoy.io"
 )
 
-requirements = ["python-socketio[client]>=4.1.0", "numpy"]
-
-if sys.version_info > (3, 0):
-    requirements += ["janus"]
-
-engine_requirements = ["aiohttp", "aiohttp_cors", "gputil", "pyyaml"]
+REQUIREMENTS = ["python-socketio[client]==4.1.0", "numpy", 'janus;python_version>"3.0"']
+ENGINE_REQUIREMENTS = ["aiohttp", "aiohttp_cors", "gputil", "pyyaml"]
 
 HERE = os.path.normpath(os.path.join(__file__, ".."))
 with open(os.path.join(HERE, "README.md"), "r") as f:
@@ -36,8 +32,8 @@ setup(
     license="MIT",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=requirements,
-    extras_require={"engine": engine_requirements, "worker": []},
+    install_requires=REQUIREMENTS,
+    extras_require={"engine": ENGINE_REQUIREMENTS, "worker": []},
     zip_safe=False,
     entry_points={"console_scripts": ["imjoy = imjoy.__main__:main"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ DESCRIPTION = (
 REQUIREMENTS = ["python-socketio[client]==4.1.0", "numpy", 'janus;python_version>"3.0"']
 ENGINE_REQUIREMENTS = ["aiohttp", "aiohttp_cors", "gputil", "pyyaml"]
 
-HERE = os.path.normpath(os.path.join(__file__, ".."))
+HERE = os.path.dirname(__file__)
 with open(os.path.join(HERE, "README.md"), "r") as f:
     README = f.read()
 

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,11 @@ if sys.version_info > (3, 0):
 
 engine_requirements = ["aiohttp", "aiohttp_cors", "gputil", "pyyaml"]
 
-HERE = os.path.normpath(os.path.join(__file__, '..'))
-with open(os.path.join(HERE, "README.md"), 'r') as f:
+HERE = os.path.normpath(os.path.join(__file__, ".."))
+with open(os.path.join(HERE, "README.md"), "r") as f:
     README = f.read()
 
-with open(os.path.join(HERE, "imjoy", "VERSION"), 'r') as f:
+with open(os.path.join(HERE, "imjoy", "VERSION"), "r") as f:
     VERSION = json.load(f)["version"]
 
 setup(
@@ -37,10 +37,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=requirements,
-    extras_require={
-        'engine': engine_requirements,
-        'worker': [],
-    },
+    extras_require={"engine": engine_requirements, "worker": []},
     zip_safe=False,
     entry_points={"console_scripts": ["imjoy = imjoy.__main__:main"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 """Set up the ImJoy-Engine imjoy package."""
 import os
 import sys
-import pathlib
 import subprocess
 from setuptools import setup, find_packages
 import json
@@ -11,56 +10,19 @@ DESCRIPTION = (
     "or remotely from ImJoy.io"
 )
 
-try:
-    subprocess.call(["conda", "-V"])
-    if os.name == "nt":
-        # for fixing CondaHTTPError:
-        # https://github.com/conda/conda/issues/6064#issuecomment-458389796
-        process = subprocess.Popen(
-            ["conda", "info", "--json", "-s"], stdout=subprocess.PIPE
-        )
-        cout, err = process.communicate()
-        conda_prefix = json.loads(cout.decode("ascii"))["conda_prefix"]
-        print("Found conda environment: {}".format(conda_prefix))
-        os.environ["PATH"] = (
-            os.path.join(conda_prefix, "Library", "bin")
-            + os.pathsep
-            + os.environ["PATH"]
-        )
-except OSError:
-    if sys.version_info > (3, 0):
-        print(
-            "WARNING: you are running ImJoy without conda, "
-            "you may have problem with some plugins"
-        )
-    else:
-        sys.exit(
-            "Sorry, ImJoy Python Plugin Engine can only run within a conda environment "
-            "or at least in Python 3."
-        )
+requirements = ["python-socketio[client]>=4.1.0", "numpy"]
 
-requirements = []
 if sys.version_info > (3, 0):
-    requirements = ["aiohttp", "aiohttp_cors", "gputil", "python-socketio", "pyyaml"]
-    print("Trying to install psutil with pip")
-    ret = subprocess.Popen(
-        ["pip", "install", "psutil"], env=os.environ.copy(), shell=False
-    ).wait()
-    if ret != 0:
-        print("Trying to install psutil with conda")
-        ret2 = subprocess.Popen(
-            ["conda", "install", "-y", "psutil"], env=os.environ.copy()
-        ).wait()
-        if ret2 != 0:
-            raise Exception(
-                "Failed to install psutil, "
-                "please try to setup an environment with gcc support."
-            )
+    requirements += ["janus"]
 
+engine_requirements = ["aiohttp", "aiohttp_cors", "gputil", "pyyaml"]
 
-HERE = pathlib.Path(__file__).parent
-README = (HERE / "README.md").read_text()
-VERSION = json.loads((HERE / "imjoy" / "VERSION").read_text())["version"]
+HERE = os.path.normpath(os.path.join(__file__, '..'))
+with open(os.path.join(HERE, "README.md"), 'r') as f:
+    README = f.read()
+
+with open(os.path.join(HERE, "imjoy", "VERSION"), 'r') as f:
+    VERSION = json.load(f)["version"]
 
 setup(
     name="imjoy",
@@ -75,6 +37,10 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=requirements,
+    extras_require={
+        'engine': engine_requirements,
+        'worker': [],
+    },
     zip_safe=False,
     entry_points={"console_scripts": ["imjoy = imjoy.__main__:main"]},
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from tests.fake_client import TestClient
 @pytest.fixture(name="engine")
 def setup_engine():
     """Set up engine."""
-    engine_args = f"python {ENGINE_MODULE} --debug --token {TOKEN}"
+    engine_args = f"python {ENGINE_MODULE} --dev --debug --token {TOKEN}"
     process = subprocess.Popen(engine_args.split())
     time.sleep(2)  # This is needed to let the engine finish setup.
     yield


### PR DESCRIPTION
This PR simplify the requirements, and introduces `extras_require` to support:
 * when running `pip install imjoy` or `pip install imjoy[worker]` only requirements for the workers will be installed
 * when running `pip install imjoy[engine]` it will add extra requirements for running the engine
 * when running `imjoy` or `python -m imjoy`, it will upgrade the engine with `pip install imjoy[engine]` 

It also reduces the occurrence of required packages into only once (in `setup.py`), the default plugin requirements becomes only `imjoy[engine]`. 

When running `imjoy --dev`, for each plugin process, the imjoy package folder will be added to `PYTHONPATH` and use `python -m workers.python_worker`, otherwise, the installed version will be used by running `python -m imjoy.workers.python_worker`.

Replace `pathlib` in setup.py to be compatible with python2 such that `pip install imjoy` can run in python2.

We should close #70 , in favor of this one.