### PR TITLE
Support home in file dialog

### DIFF
--- a/imjoy/VERSION
+++ b/imjoy/VERSION
@@ -1,4 +1,4 @@
 {
-    "version": "0.8.18",
+    "version": "0.8.19",
     "api_version": "0.1.2"
 }

--- a/imjoy/VERSION
+++ b/imjoy/VERSION
@@ -1,4 +1,4 @@
 {
-    "version": "0.8.17",
+    "version": "0.8.18",
     "api_version": "0.1.2"
 }

--- a/imjoy/connection/handler.py
+++ b/imjoy/connection/handler.py
@@ -86,4 +86,4 @@ async def disconnect(engine, sid):
         if not event.startswith("disconnect_"):
             continue
         await handler(sid)
-    logger.info("Client(%s) disconneted", sid)
+    logger.info("Client(%s) disconnected", sid)

--- a/imjoy/runners/helper.py
+++ b/imjoy/runners/helper.py
@@ -53,7 +53,7 @@ def install_reqs(
     cmd_history = engine.store.cmd_history
     commands = []
     code = 0
-    error = None
+    errors = None
 
     for cmd in reqs_cmds:
         if cmd in cmd_history:
@@ -64,11 +64,11 @@ def install_reqs(
     def fail_install():
         """Notify of failed installation."""
         logging_callback(
-            f"Failed to install dependencies with exit code {code} and error: {error}",
+            f"Failed to install dependencies with exit code {code} and error: {errors}",
             type="error",
         )
         raise Exception(
-            f"Failed to install dependencies with exit code {code} and error: {error}"
+            f"Failed to install dependencies with exit code {code} and error: {errors}"
         )
 
     def _process_start(pid=None, cmd=None):

--- a/imjoy/runners/subprocess.py
+++ b/imjoy/runners/subprocess.py
@@ -637,7 +637,11 @@ def launch_plugin(
         default_virtual_env = default_virtual_env.replace(" ", "_")
         venv_name, envs, is_py2 = parse_env(engine, env, work_dir, default_virtual_env)
         environment_variables = {}
-        default_requirements = ["imjoy[worker]==" + __version__]
+
+        if engine.opt.dev:
+            default_requirements = ["imjoy[worker]"]
+        else:
+            default_requirements = ["imjoy[worker]==" + __version__]
         default_reqs_cmds = parse_requirements(
             default_requirements, conda=opt.conda_available
         )

--- a/imjoy/services/file_server.py
+++ b/imjoy/services/file_server.py
@@ -50,7 +50,7 @@ async def on_list_dir(engine, sid, kwargs):
         files_list["type"] = "dir"
         files_list["children"] = scandir(files_list["path"], type_, recursive)
 
-        if sys.platform == "win32" and os.path.abspath(path) == os.path.abspath("/"):
+        if sys.platform == "win32":
             files_list["drives"] = get_drives()
 
         return files_list

--- a/imjoy/services/file_server.py
+++ b/imjoy/services/file_server.py
@@ -44,6 +44,7 @@ async def on_list_dir(engine, sid, kwargs):
         type_ = kwargs.get("type")
         recursive = kwargs.get("recursive", False)
         files_list = {"success": True}
+        files_list["sep"] = os.sep
         files_list["path"] = path
         files_list["name"] = os.path.basename(os.path.abspath(path))
         files_list["type"] = "dir"

--- a/imjoy/services/file_server.py
+++ b/imjoy/services/file_server.py
@@ -36,10 +36,10 @@ async def on_list_dir(engine, sid, kwargs):
         )
 
         path = kwargs.get("path", workspace_dir)
-
+        path = os.path.normpath(os.path.expanduser(path))
         if not os.path.isabs(path):
             path = os.path.join(workspace_dir, path)
-        path = os.path.normpath(os.path.expanduser(path))
+        path = os.path.abspath(path)
 
         type_ = kwargs.get("type")
         recursive = kwargs.get("recursive", False)


### PR DESCRIPTION
As reported by @muellerflorian , currently `api.showFileDialog(uri_type="path",root='~')`, the root folder will be translated to`os.path.join(WORKSPACE, '~')`, this is a fix for it.